### PR TITLE
Less error prone way to serialize common structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(alicia-libserver STATIC
         src/libserver/base/Server.cpp
         src/libserver/command/CommandProtocol.cpp
         src/libserver/command/CommandServer.cpp
+        src/libserver/command/proto/DataDefines.cpp
         src/libserver/command/proto/LobbyMessageDefines.cpp
         src/libserver/command/proto/RaceMessageDefines.cpp
         src/libserver/command/proto/RanchMessageDefines.cpp

--- a/include/libserver/command/proto/DataDefines.hpp
+++ b/include/libserver/command/proto/DataDefines.hpp
@@ -25,6 +25,8 @@
 #include <vector>
 #include <string>
 
+#include "libserver/Util.hpp"
+
 namespace alicia
 {
 
@@ -56,7 +58,12 @@ struct Item
   uint32_t tid{};
   uint32_t val{};
   uint32_t count{};
+
+  static void Write(const Item& item, SinkStream& buffer);
+  static void Read(Item& item, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(Item);
 
 //!
 enum class OptionType : uint32_t
@@ -75,15 +82,29 @@ struct KeyboardOptions
     uint16_t index{};
     uint8_t type{};
     uint8_t key{};
+
+    static void Write(const Option& option, SinkStream& buffer);
+    static void Read(Option& option, SourceStream& buffer);
   };
 
   std::vector<Option> bindings{};
+
+  static void Write(const KeyboardOptions& value, SinkStream& buffer);
+  static void Read(KeyboardOptions& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(KeyboardOptions::Option);
+DECLARE_WRITER_READER(KeyboardOptions);
 
 struct MacroOptions
 {
   std::array<std::string, 8> macros;
+
+  static void Write(const MacroOptions& value, SinkStream& buffer);
+  static void Read(MacroOptions& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(MacroOptions);
 
 struct Character
 {
@@ -97,6 +118,9 @@ struct Character
     uint8_t faceSerialId{};
 
     uint8_t val0{};
+
+    static void Write(const CharacterParts& value, SinkStream& buffer);
+    static void Read(CharacterParts& value, SourceStream& buffer);
   } parts{};
 
   //! Seems to not be based on any physical units...
@@ -113,8 +137,18 @@ struct Character
     uint16_t legVolume{};
 
     uint16_t val1{};
+
+    static void Write(const CharacterAppearance& value, SinkStream& buffer);
+    static void Read(CharacterAppearance& value, SourceStream& buffer);
   } appearance{};
+
+  static void Write(const Character& value, SinkStream& buffer);
+  static void Read(Character& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(Character::CharacterParts);
+DECLARE_WRITER_READER(Character::CharacterAppearance);
+DECLARE_WRITER_READER(Character);
 
 struct Horse
 {
@@ -128,6 +162,9 @@ struct Horse
     uint8_t maneId{};
     uint8_t tailId{};
     uint8_t faceId{};
+
+    static void Write(const Parts& value, SinkStream& buffer);
+    static void Read(Parts& value, SourceStream& buffer);
   } parts{};
 
   //! Figure
@@ -138,6 +175,9 @@ struct Horse
     uint8_t legVolume{};
     uint8_t bodyLength{};
     uint8_t bodyVolume{};
+
+    static void Write(const Appearance& value, SinkStream& buffer);
+    static void Read(Appearance& value, SourceStream& buffer);
   } appearance{};
 
   struct Stats
@@ -147,6 +187,9 @@ struct Horse
     uint32_t speed{};
     uint32_t strength{};
     uint32_t ambition{};
+
+    static void Write(const Stats& value, SinkStream& buffer);
+    static void Read(Stats& value, SourceStream& buffer);
   } stats{};
 
   uint32_t rating{};
@@ -211,11 +254,23 @@ struct Horse
     uint32_t sliding{};
     //! Divided by 10?
     uint32_t gliding{};
+
+    static void Write(const Mastery& value, SinkStream& buffer);
+    static void Read(Mastery& value, SourceStream& buffer);
   } mastery{};
 
   uint32_t val16{};
   uint32_t val17{};
+
+  static void Write(const Horse& value, SinkStream& buffer);
+  static void Read(Horse& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(Horse);
+DECLARE_WRITER_READER(Horse::Parts);
+DECLARE_WRITER_READER(Horse::Appearance);
+DECLARE_WRITER_READER(Horse::Stats);
+DECLARE_WRITER_READER(Horse::Mastery);
 
 //!
 struct Struct5
@@ -228,7 +283,12 @@ struct Struct5
   uint32_t val5{};
   // ignored by the client?
   uint8_t val6{};
+
+  static void Write(const Struct5& value, SinkStream& buffer);
+  static void Read(Struct5& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(Struct5);
 
 //!
 struct Struct6
@@ -236,7 +296,12 @@ struct Struct6
   uint32_t mountUid{};
   uint32_t val1{};
   uint32_t val2{};
+
+  static void Write(const Struct6& value, SinkStream& buffer);
+  static void Read(Struct6& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(Struct6);
 
 //!
 struct Struct7
@@ -245,13 +310,23 @@ struct Struct7
   uint32_t val1{};
   std::string val2{};
   uint32_t val3{};
+
+  static void Write(const Struct7& value, SinkStream& buffer);
+  static void Read(Struct7& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(Struct7);
 
 //!
 struct RanchHorse {
   uint16_t ranchIndex{};
   Horse horse{};
+
+  static void Write(const RanchHorse& value, SinkStream& buffer);
+  static void Read(RanchHorse& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(RanchHorse);
 
 //!
 struct RanchPlayer
@@ -278,7 +353,12 @@ struct RanchPlayer
 
   uint8_t unk4{};
   uint8_t unk5{};
+
+  static void Write(const RanchPlayer& value, SinkStream& buffer);
+  static void Read(RanchPlayer& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(RanchPlayer);
 
 struct Quest
 {
@@ -287,7 +367,12 @@ struct Quest
   uint32_t unk2{};
   uint8_t unk3{};
   uint8_t unk4{};
+
+  static void Write(const Quest& value, SinkStream& buffer);
+  static void Read(Quest& value, SourceStream& buffer);
 };
+
+DECLARE_WRITER_READER(Quest);
 
 } // namespace alicia
 

--- a/include/libserver/command/proto/LobbyMessageDefines.hpp
+++ b/include/libserver/command/proto/LobbyMessageDefines.hpp
@@ -30,26 +30,6 @@
 
 namespace alicia
 {
-
-//! Writes item data to the buffer.
-//! @param buf Sink buffer.
-//! @param item Item data to write.
-void WriteItem(SinkStream& buf, const Item& item);
-
-//! Writes character data to the buffer.
-//! @param buf Sink buffer.
-//! @param character Character data to write.
-void WriteCharacter(
-  SinkStream& buf,
-  const Character& character);
-
-//! Writes horse data to the buffer.
-//! @param buf Sink buffer.
-//! @param horse Horse data to write.
-void WriteHorse(
-  SinkStream& buf,
-  const Horse& horse);
-
 //! Serverbound login command.
 struct LobbyCommandLogin
 {

--- a/src/libserver/command/proto/DataDefines.cpp
+++ b/src/libserver/command/proto/DataDefines.cpp
@@ -1,0 +1,517 @@
+/**
+* Alicia Server - dedicated server software
+* Copyright (C) 2024 Story Of Alicia
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program; if not, write to the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+**/
+
+#include "libserver/command/proto/DataDefines.hpp"
+
+namespace alicia
+{
+
+void Item::Write(const Item& item, SinkStream& buffer)
+{
+    buffer.Write(item.uid)
+        .Write(item.tid)
+        .Write(item.val)
+        .Write(item.count);
+}
+
+void Item::Read(Item& item, SourceStream& buffer)
+{
+    buffer.Read(item.uid)
+        .Read(item.tid)
+        .Read(item.val)
+        .Read(item.count);
+}
+
+DEFINE_WRITER_READER(Item, Item::Write, Item::Read)
+
+
+void KeyboardOptions::Option::Write(const Option& option, SinkStream& buffer)
+{
+    buffer.Write(option.index)
+        .Write(option.type)
+        .Write(option.key);
+}
+
+void KeyboardOptions::Option::Read(Option& option, SourceStream& buffer)
+{
+    buffer.Read(option.index)
+        .Read(option.type)
+        .Read(option.key);
+}
+
+DEFINE_WRITER_READER(KeyboardOptions::Option, KeyboardOptions::Option::Write, KeyboardOptions::Option::Read)
+
+
+void KeyboardOptions::Write(const KeyboardOptions& value, SinkStream& buffer)
+{
+    buffer.Write(static_cast<uint8_t>(value.bindings.size()));
+    for (const auto& binding : value.bindings)
+    {
+        buffer.Write(binding);
+    }
+}
+
+void KeyboardOptions::Read(KeyboardOptions& value, SourceStream& buffer)
+{
+    uint8_t size;
+    buffer.Read(size);
+    value.bindings.resize(size);
+    for (auto& binding : value.bindings)
+    {
+        buffer.Read(binding);
+    }
+}
+
+DEFINE_WRITER_READER(KeyboardOptions, KeyboardOptions::Write, KeyboardOptions::Read)
+
+
+void MacroOptions::Write(const MacroOptions& value, SinkStream& buffer)
+{
+    for (const auto& macro : value.macros)
+    {
+        buffer.Write(macro);
+    }
+}
+
+void MacroOptions::Read(MacroOptions& value, SourceStream& buffer)
+{
+    for (auto& macro : value.macros)
+    {
+        buffer.Read(macro);
+    }
+}
+
+DEFINE_WRITER_READER(MacroOptions, MacroOptions::Write, MacroOptions::Read)
+
+
+void Character::CharacterParts::Write(const CharacterParts& value, SinkStream& buffer)
+{
+    buffer.Write(value.charId)
+        .Write(value.mouthSerialId)
+        .Write(value.faceSerialId)
+        .Write(value.val0);
+}
+
+void Character::CharacterParts::Read(CharacterParts& value, SourceStream& buffer)
+{
+    buffer.Read(value.charId)
+        .Read(value.mouthSerialId)
+        .Read(value.faceSerialId)
+        .Read(value.val0);
+}
+
+DEFINE_WRITER_READER(Character::CharacterParts, Character::CharacterParts::Write, Character::CharacterParts::Read)
+
+
+void Character::CharacterAppearance::Write(const CharacterAppearance& value, SinkStream& buffer)
+{
+    buffer.Write(value.val0)
+        .Write(value.headSize)
+        .Write(value.height)
+        .Write(value.thighVolume)
+        .Write(value.legVolume)
+        .Write(value.val1);
+}
+
+void Character::CharacterAppearance::Read(CharacterAppearance& value, SourceStream& buffer)
+{
+    buffer.Read(value.val0)
+        .Read(value.headSize)
+        .Read(value.height)
+        .Read(value.thighVolume)
+        .Read(value.legVolume)
+        .Read(value.val1);
+}
+
+DEFINE_WRITER_READER(Character::CharacterAppearance, Character::CharacterAppearance::Write, Character::CharacterAppearance::Read)
+
+
+void Character::Write(const Character& value, SinkStream& buffer)
+{
+    buffer.Write(value.parts)
+        .Write(value.appearance);
+}
+
+void Character::Read(Character& value, SourceStream& buffer)
+{
+    buffer.Read(value.parts)
+        .Read(value.appearance);
+}
+
+DEFINE_WRITER_READER(Character, Character::Write, Character::Read)
+
+
+void Horse::Parts::Write(const Parts& value, SinkStream& buffer)
+{
+    buffer.Write(value.skinId)
+        .Write(value.maneId)
+        .Write(value.tailId)
+        .Write(value.faceId);
+}
+
+void Horse::Parts::Read(Parts& value, SourceStream& buffer)
+{
+    buffer.Read(value.skinId)
+        .Read(value.maneId)
+        .Read(value.tailId)
+        .Read(value.faceId);
+}
+
+DEFINE_WRITER_READER(Horse, Horse::Write, Horse::Read)
+
+
+void Horse::Appearance::Write(const Appearance& value, SinkStream& buffer)
+{
+    buffer.Write(value.scale)
+        .Write(value.legLength)
+        .Write(value.legVolume)
+        .Write(value.bodyLength)
+        .Write(value.bodyVolume);
+}
+
+void Horse::Appearance::Read(Appearance& value, SourceStream& buffer)
+{
+    buffer.Read(value.scale)
+        .Read(value.legLength)
+        .Read(value.legVolume)
+        .Read(value.bodyLength)
+        .Read(value.bodyVolume);
+}
+
+DEFINE_WRITER_READER(Horse::Parts, Horse::Parts::Write, Horse::Parts::Read)
+
+
+void Horse::Stats::Write(const Stats& value, SinkStream& buffer)
+{
+    buffer.Write(value.agility)
+        .Write(value.spirit)
+        .Write(value.speed)
+        .Write(value.strength)
+        .Write(value.ambition);
+}
+
+void Horse::Stats::Read(Stats& value, SourceStream& buffer)
+{
+    buffer.Read(value.agility)
+        .Read(value.spirit)
+        .Read(value.speed)
+        .Read(value.strength)
+        .Read(value.ambition);
+}
+
+DEFINE_WRITER_READER(Horse::Appearance, Horse::Appearance::Write, Horse::Appearance::Read)
+
+
+void Horse::Mastery::Write(const Mastery& value, SinkStream& buffer)
+{
+    buffer.Write(value.magic)
+        .Write(value.jumping)
+        .Write(value.sliding)
+        .Write(value.gliding);
+}
+
+void Horse::Mastery::Read(Mastery& value, SourceStream& buffer)
+{
+    buffer.Read(value.magic)
+        .Read(value.jumping)
+        .Read(value.sliding)
+        .Read(value.gliding);
+}
+
+DEFINE_WRITER_READER(Horse::Stats, Horse::Stats::Write, Horse::Stats::Read)
+
+
+void Horse::Write(const Horse& value, SinkStream& buffer)
+{
+    buffer.Write(value.uid)
+        .Write(value.tid)
+        .Write(value.name);
+
+    buffer.Write(value.parts)
+        .Write(value.appearance)
+        .Write(value.stats);
+
+    buffer.Write(value.rating)
+        .Write(value.clazz)
+        .Write(value.val0)
+        .Write(value.grade)
+        .Write(value.growthPoints);
+
+    buffer.Write(value.vals0.stamina)
+        .Write(value.vals0.attractiveness)
+        .Write(value.vals0.hunger)
+        .Write(value.vals0.val0)
+        .Write(value.vals0.val1)
+        .Write(value.vals0.val2)
+        .Write(value.vals0.val3)
+        .Write(value.vals0.val4)
+        .Write(value.vals0.val5)
+        .Write(value.vals0.val6)
+        .Write(value.vals0.val7)
+        .Write(value.vals0.val8)
+        .Write(value.vals0.val9)
+        .Write(value.vals0.val10);
+
+    buffer.Write(value.vals1.val0)
+        .Write(value.vals1.val1)
+        .Write(value.vals1.val2)
+        .Write(value.vals1.val3)
+        .Write(value.vals1.val4)
+        .Write(value.vals1.classProgression)
+        .Write(value.vals1.val5)
+        .Write(value.vals1.val6)
+        .Write(value.vals1.val7)
+        .Write(value.vals1.val8)
+        .Write(value.vals1.val9)
+        .Write(value.vals1.val10)
+        .Write(value.vals1.val11)
+        .Write(value.vals1.val12)
+        .Write(value.vals1.val13)
+        .Write(value.vals1.val14)
+        .Write(value.vals1.val15);
+
+    buffer.Write(value.mastery);
+
+    buffer.Write(value.val16)
+        .Write(value.val17);
+}
+
+void Horse::Read(Horse& value, SourceStream& buffer)
+{
+    buffer.Read(value.uid)
+        .Read(value.tid)
+        .Read(value.name);
+
+    buffer.Read(value.parts)
+        .Read(value.appearance)
+        .Read(value.stats);
+
+    buffer.Read(value.rating)
+        .Read(value.clazz)
+        .Read(value.val0)
+        .Read(value.grade)
+        .Read(value.growthPoints);
+
+    buffer.Read(value.vals0.stamina)
+        .Read(value.vals0.attractiveness)
+        .Read(value.vals0.hunger)
+        .Read(value.vals0.val0)
+        .Read(value.vals0.val1)
+        .Read(value.vals0.val2)
+        .Read(value.vals0.val3)
+        .Read(value.vals0.val4)
+        .Read(value.vals0.val5)
+        .Read(value.vals0.val6)
+        .Read(value.vals0.val7)
+        .Read(value.vals0.val8)
+        .Read(value.vals0.val9)
+        .Read(value.vals0.val10);
+
+    buffer.Read(value.vals1.val0)
+        .Read(value.vals1.val1)
+        .Read(value.vals1.val2)
+        .Read(value.vals1.val3)
+        .Read(value.vals1.val4)
+        .Read(value.vals1.classProgression)
+        .Read(value.vals1.val5)
+        .Read(value.vals1.val6)
+        .Read(value.vals1.val7)
+        .Read(value.vals1.val8)
+        .Read(value.vals1.val9)
+        .Read(value.vals1.val10)
+        .Read(value.vals1.val11)
+        .Read(value.vals1.val12)
+        .Read(value.vals1.val13)
+        .Read(value.vals1.val14)
+        .Read(value.vals1.val15);
+
+    buffer.Read(value.mastery);
+
+    buffer.Read(value.val16)
+        .Read(value.val17);
+}
+
+DEFINE_WRITER_READER(Horse::Mastery, Horse::Mastery::Write, Horse::Mastery::Read)
+
+
+void Struct5::Write(const Struct5& value, SinkStream& buffer)
+{
+    buffer.Write(value.val0)
+        .Write(value.val1)
+        .Write(value.val2)
+        .Write(value.val3)
+        .Write(value.val4)
+        .Write(value.val5)
+        .Write(value.val6);
+}
+
+void Struct5::Read(Struct5& value, SourceStream& buffer)
+{
+    buffer.Read(value.val0)
+        .Read(value.val1)
+        .Read(value.val2)
+        .Read(value.val3)
+        .Read(value.val4)
+        .Read(value.val5)
+        .Read(value.val6);
+}
+
+DEFINE_WRITER_READER(Struct5, Struct5::Write, Struct5::Read)
+
+
+void Struct6::Write(const Struct6& value, SinkStream& buffer)
+{
+    buffer.Write(value.mountUid)
+        .Write(value.val1)
+        .Write(value.val2);
+}
+
+void Struct6::Read(Struct6& value, SourceStream& buffer)
+{
+    buffer.Read(value.mountUid)
+        .Read(value.val1)
+        .Read(value.val2);
+}
+
+DEFINE_WRITER_READER(Struct6, Struct6::Write, Struct6::Read)
+
+
+void Struct7::Write(const Struct7& value, SinkStream& buffer)
+{
+    buffer.Write(value.val0)
+        .Write(value.val1)
+        .Write(value.val2)
+        .Write(value.val3);
+}
+
+void Struct7::Read(Struct7& value, SourceStream& buffer)
+{
+    buffer.Read(value.val0)
+        .Read(value.val1)
+        .Read(value.val2)
+        .Read(value.val3);
+}
+
+DEFINE_WRITER_READER(Struct7, Struct7::Write, Struct7::Read)
+
+
+void RanchHorse::Write(const RanchHorse& value, SinkStream& buffer)
+{
+    buffer.Write(value.ranchIndex)
+        .Write(value.horse);
+}
+
+void RanchHorse::Read(RanchHorse& value, SourceStream& buffer)
+{
+    buffer.Read(value.ranchIndex)
+        .Read(value.horse);
+}
+
+DEFINE_WRITER_READER(RanchHorse, RanchHorse::Write, RanchHorse::Read)
+
+
+void RanchPlayer::Write(const RanchPlayer& value, SinkStream& buffer)
+{
+    buffer.Write(value.userUid)
+        .Write(value.name)
+        .Write(static_cast<uint8_t>(value.gender))
+        .Write(value.unk0)
+        .Write(value.unk1)
+        .Write(value.description);
+
+    buffer.Write(value.character)
+        .Write(value.horse);
+
+    buffer.Write(static_cast<uint8_t>(value.characterEquipment.size()));
+    for (const auto& item : value.characterEquipment)
+    {
+        buffer.Write(item);
+    }
+
+    buffer.Write(value.playerRelatedThing);
+
+    buffer.Write(value.ranchIndex)
+        .Write(value.unk2)
+        .Write(value.unk3);
+
+    buffer.Write(value.anotherPlayerRelatedThing)
+        .Write(value.yetAnotherPlayerRelatedThing);
+
+    buffer.Write(value.unk4)
+        .Write(value.unk5);
+}
+
+void RanchPlayer::Read(RanchPlayer& value, SourceStream& buffer)
+{
+    buffer.Read(value.userUid)
+        .Read(value.name)
+        .Read(reinterpret_cast<uint8_t&>(value.gender))
+        .Read(value.unk0)
+        .Read(value.unk1)
+        .Read(value.description);
+
+    buffer.Read(value.character)
+        .Read(value.horse);
+
+    uint8_t size;
+    buffer.Read(size);
+    value.characterEquipment.resize(size);
+    for (auto& item : value.characterEquipment)
+    {
+        buffer.Read(item);
+    }
+
+    buffer.Read(value.playerRelatedThing);
+
+    buffer.Read(value.ranchIndex)
+        .Read(value.unk2)
+        .Read(value.unk3);
+
+    buffer.Read(value.anotherPlayerRelatedThing)
+        .Read(value.yetAnotherPlayerRelatedThing);
+
+    buffer.Read(value.unk4)
+        .Read(value.unk5);
+}
+
+DEFINE_WRITER_READER(RanchPlayer, RanchPlayer::Write, RanchPlayer::Read)
+
+
+void Quest::Write(const Quest& value, SinkStream& buffer)
+{
+    buffer.Write(value.unk0)
+        .Write(value.unk1)
+        .Write(value.unk2)
+        .Write(value.unk3)
+        .Write(value.unk4);
+}
+
+void Quest::Read(Quest& value, SourceStream& buffer)
+{
+    buffer.Read(value.unk0)
+        .Read(value.unk1)
+        .Read(value.unk2)
+        .Read(value.unk3)
+        .Read(value.unk4);
+}
+
+DEFINE_WRITER_READER(Quest, Quest::Write, Quest::Read)
+
+
+} // namespace alicia

--- a/src/libserver/command/proto/LobbyMessageDefines.cpp
+++ b/src/libserver/command/proto/LobbyMessageDefines.cpp
@@ -24,152 +24,6 @@
 namespace alicia
 {
 
-//! Writes item data to the buffer.
-//! @param buf Sink buffer.
-//! @param item Item data to write.
-void WriteItem(SinkStream& buf, const Item& item)
-{
-  buf.Write(item.uid)
-    .Write(item.tid)
-    .Write(item.val)
-    .Write(item.count);
-}
-
-//! Writes character data to the buffer.
-//! @param buf Sink buffer.
-//! @param character Character data to write.
-void WriteCharacter(
-  SinkStream& buf,
-  const Character& character)
-{
-  const auto& [parts, appearance] = character;
-
-  // Write the character parts.
-  buf.Write(parts.charId)
-    .Write(parts.mouthSerialId)
-    .Write(parts.faceSerialId)
-    .Write(parts.val0);
-
-  // Write the character appearance.
-  buf.Write(appearance.val0)
-    .Write(appearance.headSize)
-    .Write(appearance.height)
-    .Write(appearance.thighVolume)
-    .Write(appearance.legVolume)
-    .Write(appearance.val1);
-}
-
-//! Reads character data from the buffer.
-//! @param buf Source buffer.
-//! @param character Character data to read.
-void ReadCharacter(
-  SourceStream& buf,
-  Character& character)
-{
-  auto& [parts, appearance] = character;
-
-  // Write the character parts.
-  buf.Read(parts.charId)
-    .Read(parts.mouthSerialId)
-    .Read(parts.faceSerialId)
-    .Read(parts.val0);
-
-  // Write the character appearance.
-  buf.Read(appearance.val0)
-    .Read(appearance.headSize)
-    .Read(appearance.height)
-    .Read(appearance.thighVolume)
-    .Read(appearance.legVolume)
-    .Read(appearance.val1);
-}
-
-//! Writes horse data to the buffer.
-//! @param buf Sink buffer.
-//! @param horse Horse data to write.
-void WriteHorse(
-  SinkStream& buf,
-  const Horse& horse)
-{
-  // Horse identifiers.
-  buf.Write(horse.uid)
-    .Write(horse.tid)
-    .Write(horse.name);
-
-  // Horse parts.
-  const auto& parts = horse.parts;
-  buf.Write(parts.skinId)
-    .Write(parts.maneId)
-    .Write(parts.tailId)
-    .Write(parts.faceId);
-
-  // Horse appearance.
-  const auto& appearance = horse.appearance;
-  buf.Write(appearance.scale)
-    .Write(appearance.legLength)
-    .Write(appearance.legVolume)
-    .Write(appearance.bodyLength)
-    .Write(appearance.bodyVolume);
-
-  // Horse stats.
-  const auto& stats = horse.stats;
-  buf.Write(stats.agility)
-    .Write(stats.spirit)
-    .Write(stats.speed)
-    .Write(stats.strength)
-    .Write(stats.ambition);
-
-  buf.Write(horse.rating)
-    .Write(horse.clazz)
-    .Write(horse.val0)
-    .Write(horse.grade)
-    .Write(horse.growthPoints);
-
-  const auto& vals0 = horse.vals0;
-  buf.Write(vals0.stamina)
-    .Write(vals0.attractiveness)
-    .Write(vals0.hunger)
-    .Write(vals0.val0)
-    .Write(vals0.val1)
-    .Write(vals0.val2)
-    .Write(vals0.val3)
-    .Write(vals0.val4)
-    .Write(vals0.val5)
-    .Write(vals0.val6)
-    .Write(vals0.val7)
-    .Write(vals0.val8)
-    .Write(vals0.val9)
-    .Write(vals0.val10);
-
-  const auto& vals1 = horse.vals1;
-  buf.Write(vals1.val0)
-    .Write(vals1.val1)
-    .Write(vals1.val2)
-    .Write(vals1.val3)
-    .Write(vals1.val4)
-    .Write(vals1.classProgression)
-    .Write(vals1.val5)
-    .Write(vals1.val6)
-    .Write(vals1.val7)
-    .Write(vals1.val8)
-    .Write(vals1.val9)
-    .Write(vals1.val10)
-    .Write(vals1.val11)
-    .Write(vals1.val12)
-    .Write(vals1.val13)
-    .Write(vals1.val14)
-    .Write(vals1.val15);
-
-  // Horse mastery.
-  const auto& mastery = horse.mastery;
-  buf.Write(mastery.magic)
-    .Write(mastery.jumping)
-    .Write(mastery.sliding)
-    .Write(mastery.gliding);
-
-  buf.Write(horse.val16)
-    .Write(horse.val17);
-}
-
 void LobbyCommandLogin::Write(
   const LobbyCommandLogin& command, SinkStream& buffer)
 {
@@ -206,7 +60,7 @@ void LobbyCommandLoginOK::Write(
     command.characterEquipment.size()));
   for (const Item& item : command.characterEquipment)
   {
-    WriteItem(buffer, item);
+    buffer.Write(item);
   }
 
   // Horse equipment
@@ -214,7 +68,7 @@ void LobbyCommandLoginOK::Write(
     command.horseEquipment.size()));
   for (const Item& item : command.horseEquipment)
   {
-    WriteItem(buffer, item);
+    buffer.Write(item);
   }
 
   //
@@ -289,8 +143,8 @@ void LobbyCommandLoginOK::Write(
     .Write(command.port)
     .Write(command.scramblingConstant);
 
-  WriteCharacter(buffer, command.character);
-  WriteHorse(buffer, command.horse);
+  buffer.Write(command.character)
+    .Write(command.horse);
 
   // Struct1
   const auto& struct0 = command.val7;
@@ -409,13 +263,13 @@ void LobbyCommandShowInventoryOK::Write(
   buffer.Write(static_cast<uint8_t>(command.items.size()));
   for (const auto& item : command.items)
   {
-    WriteItem(buffer, item);
+    buffer.Write(item);
   }
 
   buffer.Write(static_cast<uint8_t>(command.horses.size()));
   for (const auto& horse : command.horses)
   {
-    WriteHorse(buffer, horse);
+    buffer.Write(horse);
   }
 }
 
@@ -448,9 +302,9 @@ void LobbyCommandCreateNicknameOK::Read(
   LobbyCommandCreateNicknameOK& command,
   SourceStream& buffer)
 {
-  buffer.Read(command.nickname);
-  ReadCharacter(buffer, command.character);
-  buffer.Read(command.unk0);
+  buffer.Read(command.nickname)
+    .Read(command.character)
+    .Read(command.unk0);
 }
 
 void LobbyCommandCreateNicknameCancel::Write(

--- a/src/libserver/command/proto/RanchMessageDefines.cpp
+++ b/src/libserver/command/proto/RanchMessageDefines.cpp
@@ -56,8 +56,8 @@ void WriteMountFamilyTreeItem(
 void WriteRanchHorse(
   SinkStream& buf, const RanchHorse& ranchHorse)
 {
-  buf.Write(ranchHorse.ranchIndex);
-  WriteHorse(buf, ranchHorse.horse);
+  buf.Write(ranchHorse.ranchIndex)
+    .Write(ranchHorse.horse);
 }
 
 void WriteRanchPlayer(
@@ -70,14 +70,14 @@ void WriteRanchPlayer(
     .Write(ranchPlayer.unk1)
     .Write(ranchPlayer.description);
 
-  WriteCharacter(buf, ranchPlayer.character);
-  WriteHorse(buf, ranchPlayer.horse);
+  buf.Write(ranchPlayer.character)
+    .Write(ranchPlayer.horse);
 
   buf.Write(static_cast<uint8_t>(
     ranchPlayer.characterEquipment.size()));
   for (const Item& item : ranchPlayer.characterEquipment)
   {
-    WriteItem(buf, item);
+    buf.Write(item);
   }
 
   // Struct5


### PR DESCRIPTION
Before, it was easy to make a mistake and type ```buffer.Write(command.horse)``` instead of ```WriteHorse(buffer, command.horse)``` expecting it to work, and it would fail silently. This change allows you to use buffer.Write in the common structs from DataDefines.hpp