### PR TITLE
GHCR docker image semver/branch/pr tagging

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,13 +22,6 @@ env:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm/v7
-          - linux/arm64
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,10 +48,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.8.0
 
-      # Login against a Docker registry except on PR
+      # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -75,15 +67,21 @@ jobs:
           tags: |
             # Set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
-      # Build and push Docker image with Buildx (don't push on PR)
+      # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v6.10.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          platforms: linux/amd64  # build for amd64 only for now
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
- Tags GHCR Docker images with semver while retaining `latest` as expected. Branch tagging is also included with the future possibility that other branches may needed to be built but currently workflow only builds for `master` branch.
- Remove build matrix for now since we are not doing anything meaningful (building for amd64 with 3 separate runners).
- Allows for PRs to be built and published to GHCR to allow for testing, tagged with `pr-#` PR number.
- Builds for `amd64` only (hardcoded in action).
  - arm64 can also be built alongside amd64 and publishes correctly but with increased build time naturally.

<img width="750" height="423" alt="image" src="https://github.com/user-attachments/assets/da897d39-6116-454f-9909-08a5c82c45be" />

> GHCR Docker image with PR tag

<img width="751" height="426" alt="image" src="https://github.com/user-attachments/assets/2df0e29b-cee4-46a7-9a8b-4b9de02756de" />

> Branch tagging

<img width="293" height="117" alt="image" src="https://github.com/user-attachments/assets/b25af7a0-12de-4736-821c-f37daada4b9d" />

> Semver tagging