### PR TITLE
Fix PR Docker image push fail

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,19 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Check PR author association
+        id: check-author
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "authorised=true" >> $GITHUB_OUTPUT
+          else
+            if [ "${{ github.event.pull_request.author_association }}" = "MEMBER" ] || [ "${{ github.event.pull_request.author_association }}" = "OWNER" ]; then
+              echo "authorised=true" >> $GITHUB_OUTPUT
+            else
+              echo "authorised=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
@@ -49,8 +62,10 @@ jobs:
         uses: docker/setup-buildx-action@v3.8.0
 
       # Login against a Docker registry
+      # Only login if the author is a member of the repository or it is not a PR.
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
+        if: steps.check-author.outputs.authorised == 'true'
         uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -74,13 +89,14 @@ jobs:
             type=semver,pattern={{major}}
 
       # Build and push Docker image with Buildx
+      # Only push if the author is a member of the repository or it is not a PR.
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v6.10.0
         with:
           context: .
-          push: true
+          push: ${{ steps.check-author.outputs.authorised == 'true' }}
           platforms: linux/amd64  # build for amd64 only for now
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,7 +91,7 @@ jobs:
       # Build and push Docker image with Buildx
       # Only push if the author is a member of the repository or it is not a PR.
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build ${{ steps.check-author.outputs.authorised == 'true' && 'and push' || 'only' }} Docker image
         id: build-and-push
         uses: docker/build-push-action@v6.10.0
         with:


### PR DESCRIPTION
Checks if the `github.actor` is a member or owner of the repo and returns `authorised` where Docker either pushes or doesn't if the calling actor is authorised to push images to the repo.