### PR TITLE
Game logic discoveries

### DIFF
--- a/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
@@ -2778,15 +2778,6 @@ struct RanchCommandUseItem
   };
   Play play{};
 
-  enum class PlayResponse : uint32_t
-  {
-    Bad = 0,
-    Good = 1,
-    CriticalGood = 2,
-    Perfect = 3,
-    CriticalPerfect = 4
-  };
-
   static Command GetCommand()
   {
     return Command::AcCmdCRUseItem;
@@ -2819,13 +2810,22 @@ struct RanchCommandUseItemOK
     Action4
   };
 
+  enum class PlayResponse : uint32_t
+  {
+    Bad = 0,
+    Good = 1,
+    CriticalGood = 2,
+    Perfect = 3,
+    CriticalPerfect = 4
+  };
+
   struct ActionTwoBytes
   {
     // Gives less % as the player levels up but the unit remains the same
     // Likely means that the max percentage per level is increased
     // E.g. level 100 = 100 points, level 200 = 200 points etc (arbitrary example)
     uint8_t xpReward{};
-    RanchCommandUseItem::PlayResponse play{};
+    RanchCommandUseItemOK::PlayResponse play{};
 
     static void Write(
       const ActionTwoBytes& action,

--- a/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
@@ -2821,7 +2821,10 @@ struct RanchCommandUseItemOK
 
   struct ActionTwoBytes
   {
-    uint8_t unk0{};
+    // Gives less % as the player levels up but the unit remains the same
+    // Likely means that the max percentage per level is increased
+    // E.g. level 100 = 100 points, level 200 = 200 points etc (arbitrary example)
+    uint8_t xpReward{};
     RanchCommandUseItem::PlayResponse play{};
 
     static void Write(
@@ -2845,8 +2848,8 @@ struct RanchCommandUseItemOK
   };
 
   uint32_t itemUid{};
-  // Consume item? Setting to 0 makes the item disappear on the client
-  uint16_t unk1{};
+  // Directly reflects on the client. Setting to 0 will not show the item
+  uint16_t itemCount{};
 
   // Action points to different structures depending on type
   ActionType type{};

--- a/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
@@ -2823,7 +2823,7 @@ struct RanchCommandUseItemOK
   {
     // Gives less % as the player levels up but the unit remains the same
     // Likely means that the max percentage per level is increased
-    // E.g. level 100 = 100 points, level 200 = 200 points etc (arbitrary example)
+    // E.g. level 1 = 100 points, level 2 = 200 points etc (arbitrary example)
     uint8_t xpReward{};
     RanchCommandUseItemOK::PlayResponse play{};
 

--- a/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
@@ -77,7 +77,7 @@ void RanchCommandUseItemOK::Write(
   SinkStream& stream)
 {
   stream.Write(command.itemUid)
-    .Write(command.unk1);
+    .Write(command.itemCount);
 
   stream.Write(command.type);
   switch (command.type)

--- a/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
@@ -47,7 +47,7 @@ void RanchCommandUseItemOK::ActionTwoBytes::Write(
   const ActionTwoBytes& action,
   SinkStream& stream)
 {
-  stream.Write(action.unk0)
+  stream.Write(action.xpReward)
     .Write(action.play);
 }
 

--- a/src/server/ranch/RanchDirector.cpp
+++ b/src/server/ranch/RanchDirector.cpp
@@ -2077,12 +2077,6 @@ void RanchDirector::HandleUseItem(
     response.itemUid = command.itemUid,
     response.itemCount = command.always1,
     response.type = protocol::RanchCommandUseItemOK::ActionType::Empty};
-  
-    spdlog::debug("HandleUseItem - itemUid: {}, always1: {}, horseUid: {}, play: {}",
-      command.itemUid,
-      command.always1,
-      command.horseUid,
-      (uint32_t)command.play);
 
   const auto& clientContext = GetClientContext(clientId);
   auto characterRecord = GetServerInstance().GetDataDirector().GetCharacter(
@@ -2109,6 +2103,13 @@ void RanchDirector::HandleUseItem(
   {
     itemTid = item.tid();
   });
+
+  spdlog::debug("HandleUseItem - itemUid: {}, itemTid: {}, always1: {}, horseUid: {}, play: {}",
+    command.itemUid,
+    itemTid,
+    command.always1,
+    command.horseUid,
+    (uint32_t)command.play);
 
   if (itemTid > 41000 && itemTid < 41008)
   {

--- a/src/server/ranch/RanchDirector.cpp
+++ b/src/server/ranch/RanchDirector.cpp
@@ -2000,6 +2000,10 @@ void RanchDirector::HandleUseCleanItem(
   // brushes, always empty response
   //   success - Action empty
 
+  // Clean tab is the second tab, hence the use of RanchCommandUseItemOK::ActionType::Action2
+  response.type = protocol::RanchCommandUseItemOK::ActionType::Action2;
+  response.actionTwoBytes.play = protocol::RanchCommandUseItem::PlayResponse::CriticalGood; // 2
+
   // TODO: Update the horse's stats based on the clean item used.
 }
 
@@ -2071,7 +2075,7 @@ void RanchDirector::HandleUseItem(
 {
   protocol::RanchCommandUseItemOK response{
     response.itemUid = command.itemUid,
-    response.unk1 = command.always1,
+    response.itemCount = command.always1,
     response.type = protocol::RanchCommandUseItemOK::ActionType::Empty};
 
   const auto& clientContext = GetClientContext(clientId);

--- a/src/server/ranch/RanchDirector.cpp
+++ b/src/server/ranch/RanchDirector.cpp
@@ -2002,7 +2002,7 @@ void RanchDirector::HandleUseCleanItem(
 
   // Clean tab is the second tab, hence the use of RanchCommandUseItemOK::ActionType::Action2
   response.type = protocol::RanchCommandUseItemOK::ActionType::Action2;
-  response.actionTwoBytes.play = protocol::RanchCommandUseItem::PlayResponse::CriticalGood; // 2
+  response.actionTwoBytes.play = protocol::RanchCommandUseItemOK::PlayResponse::CriticalGood; // 2
 
   // TODO: Update the horse's stats based on the clean item used.
 }
@@ -2024,17 +2024,17 @@ void RanchDirector::HandleUsePlayItem(
   switch (command.play)
   {
     case protocol::RanchCommandUseItem::Play::Bad:
-      response.actionTwoBytes.play = protocol::RanchCommandUseItem::PlayResponse::Bad;
+      response.actionTwoBytes.play = protocol::RanchCommandUseItemOK::PlayResponse::Bad;
       break;
     case protocol::RanchCommandUseItem::Play::Good:
       response.actionTwoBytes.play = crit ?
-        protocol::RanchCommandUseItem::PlayResponse::CriticalGood :
-        protocol::RanchCommandUseItem::PlayResponse::Good;
+        protocol::RanchCommandUseItemOK::PlayResponse::CriticalGood :
+        protocol::RanchCommandUseItemOK::PlayResponse::Good;
       break;
     case protocol::RanchCommandUseItem::Play::Perfect:
       response.actionTwoBytes.play = crit ?
-        protocol::RanchCommandUseItem::PlayResponse::CriticalPerfect :
-        protocol::RanchCommandUseItem::PlayResponse::Perfect;
+        protocol::RanchCommandUseItemOK::PlayResponse::CriticalPerfect :
+        protocol::RanchCommandUseItemOK::PlayResponse::Perfect;
       break;
   }
 
@@ -2047,13 +2047,13 @@ void RanchDirector::HandleUsePlayItem(
       : command.play == protocol::RanchCommandUseItem::Play::Good
         ? "Good"
         : "Perfect",
-    response.actionTwoBytes.play == protocol::RanchCommandUseItem::PlayResponse::Bad
+    response.actionTwoBytes.play == protocol::RanchCommandUseItemOK::PlayResponse::Bad
       ? "Bad"
-      : response.actionTwoBytes.play == protocol::RanchCommandUseItem::PlayResponse::Good
+      : response.actionTwoBytes.play == protocol::RanchCommandUseItemOK::PlayResponse::Good
         ? "Good"
-        : response.actionTwoBytes.play == protocol::RanchCommandUseItem::PlayResponse::CriticalGood
+        : response.actionTwoBytes.play == protocol::RanchCommandUseItemOK::PlayResponse::CriticalGood
           ? "Critical Good"
-          : response.actionTwoBytes.play == protocol::RanchCommandUseItem::PlayResponse::Perfect
+          : response.actionTwoBytes.play == protocol::RanchCommandUseItemOK::PlayResponse::Perfect
             ? "Perfect"
             : "Critical Perfect");
 
@@ -2077,6 +2077,12 @@ void RanchDirector::HandleUseItem(
     response.itemUid = command.itemUid,
     response.itemCount = command.always1,
     response.type = protocol::RanchCommandUseItemOK::ActionType::Empty};
+  
+    spdlog::debug("HandleUseItem - itemUid: {}, always1: {}, horseUid: {}, play: {}",
+      command.itemUid,
+      command.always1,
+      command.horseUid,
+      (uint32_t)command.play);
 
   const auto& clientContext = GetClientContext(clientId);
   auto characterRecord = GetServerInstance().GetDataDirector().GetCharacter(


### PR DESCRIPTION
- `RanchCommandUseItemOK.actionTwoBytes.unk0` appears to correspond to XP reward that the client internal tracks, nuking the server did not erase this XP.
- Moved `RanchCommandUseItem::PlayResponse` to `RanchCommandUseItemOK::PlayResponse`
- Some (incomplete) progress made with regards to `HandleUseCleanItem` presenting something on the UI
- Additional logging of `HandleUseItem`