### PR TITLE
Horse stats fix

### DIFF
--- a/include/libserver/data/DataDefinitions.hpp
+++ b/include/libserver/data/DataDefinitions.hpp
@@ -282,10 +282,10 @@ struct Horse
   struct Stats
   {
     dao::Field<uint32_t> agility{0u};
-    dao::Field<uint32_t> control{0u};
-    dao::Field<uint32_t> speed{0u};
-    dao::Field<uint32_t> strength{0u};
-    dao::Field<uint32_t> spirit{0u};
+    dao::Field<uint32_t> courage{0u};
+    dao::Field<uint32_t> rush{0u};
+    dao::Field<uint32_t> endurance{0u};
+    dao::Field<uint32_t> ambition{0u};
   } stats{};
 
   struct Mastery

--- a/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
+++ b/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
@@ -203,15 +203,15 @@ struct Horse
 
   struct Stats
   {
-    //!
+    //! Agility value
     uint32_t agility{};
-    //! Ambition (control) value. 
+    //! Ambition (spirit) value. 
     uint32_t ambition{};
     //! Rush (speed) value.
     uint32_t rush{};
     //! Endurance (strength) value.
     uint32_t endurance{};
-    //! Courage (spirit) value.
+    //! Courage (control) value.
     uint32_t courage{};
 
     static void Write(const Stats& value, SinkStream& stream);

--- a/src/libserver/data/file/FileDataSource.cpp
+++ b/src/libserver/data/file/FileDataSource.cpp
@@ -317,10 +317,10 @@ void server::FileDataSource::RetrieveHorse(data::Uid uid, data::Horse& horse)
   auto stats = json["stats"];
   horse.stats = data::Horse::Stats{
     .agility = stats["agility"].get<uint32_t>(),
-    .control = stats["control"].get<uint32_t>(),
-    .speed = stats["speed"].get<uint32_t>(),
-    .strength = stats["strength"].get<uint32_t>(),
-    .spirit = stats["spirit"].get<uint32_t>()};
+    .courage = stats["courage"].get<uint32_t>(),
+    .rush = stats["rush"].get<uint32_t>(),
+    .endurance = stats["endurance"].get<uint32_t>(),
+    .ambition = stats["ambition"].get<uint32_t>()};
 
   auto mastery = json["mastery"];
   horse.mastery = data::Horse::Mastery{
@@ -379,10 +379,10 @@ void server::FileDataSource::StoreHorse(data::Uid uid, const data::Horse& horse)
 
   nlohmann::json stats;
   stats["agility"] = horse.stats.agility();
-  stats["control"] = horse.stats.control();
-  stats["speed"] = horse.stats.speed();
-  stats["strength"] = horse.stats.strength();
-  stats["spirit"] = horse.stats.spirit();
+  stats["courage"] = horse.stats.courage();
+  stats["rush"] = horse.stats.rush();
+  stats["endurance"] = horse.stats.endurance();
+  stats["ambition"] = horse.stats.ambition();
   json["stats"] = stats;
 
   nlohmann::json mastery;

--- a/src/libserver/data/helper/ProtocolHelper.cpp
+++ b/src/libserver/data/helper/ProtocolHelper.cpp
@@ -122,10 +122,10 @@ void BuildProtocolHorseStats(
 {
   protocolHorseStats = {
     .agility = stats.agility(),
-    .ambition = stats.control(),
+    .ambition = stats.spirit(),
     .rush = stats.speed(),
     .endurance = stats.strength(),
-    .courage = stats.spirit()};
+    .courage = stats.control()};
 }
 
 void BuildProtocolHorseMastery(

--- a/src/libserver/data/helper/ProtocolHelper.cpp
+++ b/src/libserver/data/helper/ProtocolHelper.cpp
@@ -122,10 +122,10 @@ void BuildProtocolHorseStats(
 {
   protocolHorseStats = {
     .agility = stats.agility(),
-    .ambition = stats.spirit(),
-    .rush = stats.speed(),
-    .endurance = stats.strength(),
-    .courage = stats.control()};
+    .ambition = stats.ambition(),
+    .rush = stats.rush(),
+    .endurance = stats.endurance(),
+    .courage = stats.courage()};
 }
 
 void BuildProtocolHorseMastery(


### PR DESCRIPTION
- Fixes incorrect assignment of some horse stats (namely control and spirit assigned to the other)
- Horse stats now stored with their protocol naming instead of names as seen on game client 

<img width="1301" height="619" alt="image" src="https://github.com/user-attachments/assets/a81cde98-8d47-412e-a39a-de170e994e37" />
