### PR TITLE
Add give preset care command

### DIFF
--- a/include/server/ranch/RanchDirector.hpp
+++ b/include/server/ranch/RanchDirector.hpp
@@ -62,6 +62,11 @@ public:
     data::Uid rancherUid,
     data::Uid horseUid);
 
+  //! New item in gift storage popup for a character registered in ranch director
+  void SendStorageNotification(
+    data::Uid characterUid,
+    protocol::AcCmdCRRequestStorage::Category category);
+
   ServerInstance& GetServerInstance();
   Config::Ranch& GetConfig();
 

--- a/src/libserver/data/file/FileDataSource.cpp
+++ b/src/libserver/data/file/FileDataSource.cpp
@@ -515,6 +515,8 @@ void server::FileDataSource::RetrieveStorageItem(data::Uid uid, data::StorageIte
   item.message = json["message"].get<std::string>();
   item.checked = json["checked"].get<bool>();
   item.expired = json["expired"].get<bool>();
+  item.created = data::Clock::time_point(std::chrono::seconds(
+    json["created"].get<uint64_t>()));
 }
 
 void server::FileDataSource::StoreStorageItem(data::Uid uid, const data::StorageItem& item)
@@ -536,6 +538,8 @@ void server::FileDataSource::StoreStorageItem(data::Uid uid, const data::Storage
   json["message"] = item.message();
   json["checked"] = item.checked();
   json["expired"] = item.expired();
+  json["created"] = std::chrono::ceil<std::chrono::seconds>(
+    item.created().time_since_epoch()).count();
 
   dataFile << json.dump(2);
 }

--- a/src/libserver/data/file/FileDataSource.cpp
+++ b/src/libserver/data/file/FileDataSource.cpp
@@ -513,10 +513,10 @@ void server::FileDataSource::RetrieveStorageItem(data::Uid uid, data::StorageIte
   item.items = json["items"].get<std::vector<data::Uid>>();
   item.sender = json["sender"].get<std::string>();
   item.message = json["message"].get<std::string>();
-  item.checked = json["checked"].get<bool>();
-  item.expired = json["expired"].get<bool>();
   item.created = data::Clock::time_point(std::chrono::seconds(
     json["created"].get<uint64_t>()));
+  item.checked = json["checked"].get<bool>();
+  item.expired = json["expired"].get<bool>();
 }
 
 void server::FileDataSource::StoreStorageItem(data::Uid uid, const data::StorageItem& item)
@@ -536,10 +536,10 @@ void server::FileDataSource::StoreStorageItem(data::Uid uid, const data::Storage
   json["items"] = item.items();
   json["sender"] = item.sender();
   json["message"] = item.message();
-  json["checked"] = item.checked();
-  json["expired"] = item.expired();
   json["created"] = std::chrono::ceil<std::chrono::seconds>(
     item.created().time_since_epoch()).count();
+  json["checked"] = item.checked();
+  json["expired"] = item.expired();
 
   dataFile << json.dump(2);
 }

--- a/src/server/ranch/RanchDirector.cpp
+++ b/src/server/ranch/RanchDirector.cpp
@@ -413,6 +413,38 @@ void RanchDirector::BroadcastUpdateMountInfoNotify(
   }
 }
 
+void RanchDirector::SendStorageNotification(
+  data::Uid characterUid,
+  protocol::AcCmdCRRequestStorage::Category category)
+{
+  ClientId clientId = -1;
+  for (auto& clientContext : _clients)
+  {
+    if (clientContext.second.characterUid == characterUid
+      && clientContext.second.isAuthorized)
+      clientId = clientContext.first;
+  }
+
+  if (clientId == -1)
+  {
+    spdlog::error("Tried to send storage notification to unknown client {} with character uid {}",
+      clientId, characterUid);
+    return;
+  }
+
+  // Setting pageCountAndNotification to 0b1 and category is enough
+  protocol::AcCmdCRRequestStorageOK response{
+    .category = category,
+    .pageCountAndNotification = 0b1};
+
+  _commandServer.QueueCommand<decltype(response)>(
+    clientId,
+    [response]()
+    {
+      return response;
+    });
+}
+
 ServerInstance& RanchDirector::GetServerInstance()
 {
   return _serverInstance;

--- a/src/server/system/ChatSystem.cpp
+++ b/src/server/system/ChatSystem.cpp
@@ -331,8 +331,13 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
             "Invalid command arguments.",
             "(//give item <count> <tid>)"};
 
-        const uint32_t itemCount = std::atoi(arguments[1].c_str());
+        const int32_t itemCount = std::atoi(arguments[1].c_str());
         const data::Uid createdItemTid = std::atoi(arguments[2].c_str());
+
+        if (itemCount < 1)
+        {
+          return {"Invalid item count"};
+        }
 
         // Create the item.
         auto createdItemUid = data::InvalidUid;
@@ -382,10 +387,15 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
             "(//give preset <all|feed|clean|play|cure|construct> [<count>])"};
 
         const auto selectedPreset = arguments[1];
-        uint32_t itemCount = 1;
+        int32_t itemCount = 1;
         // Check if <count> is supplied
         if (arguments.size() > 2)
           itemCount = std::atoi(arguments[2].c_str());
+
+        if (itemCount < 1)
+        {
+          return {"Invalid item count"};
+        }
 
         std::map<std::string, std::vector<data::Tid>> presets
         {

--- a/src/server/system/ChatSystem.cpp
+++ b/src/server/system/ChatSystem.cpp
@@ -430,30 +430,14 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
             createdItemUid = item.uid();
           });
 
-          // Create the stored item.
-          auto giftUid = data::InvalidUid;
-          const auto storedItem = _serverInstance.GetDataDirector().CreateStorageItem();
-          storedItem.Mutable([this, &giftUid, createdItemUid, itemCount, selectedItemTid](data::StorageItem& storedItem)
-          {
-            storedItem.items().emplace_back(createdItemUid);
-            storedItem.sender() = "System";
-            storedItem.message() = std::format("{}x Item '{}'", itemCount, selectedItemTid);
-            storedItem.created() = data::Clock::now();
-
-            giftUid = storedItem.uid();
-          });
-
           // Add the stored item as a gift.
-          characterRecord.Mutable([giftUid](data::Character& character)
+          characterRecord.Mutable([createdItemUid](data::Character& character)
           {
-            character.gifts().emplace_back(giftUid);
+            character.items().emplace_back(createdItemUid);
           });
         }
 
-        _serverInstance.GetRanchDirector().SendStorageNotification(
-          characterUid, protocol::AcCmdCRRequestStorage::Category::Gifts);
-
-        return {"Preset gifted. Check your inventory!"};
+        return {"Preset added to character inventory. Please restart your game to apply changes!"};
       }
 
       return {"Unknown sub-literal"};

--- a/src/server/system/ChatSystem.cpp
+++ b/src/server/system/ChatSystem.cpp
@@ -318,7 +318,7 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
       if (arguments.size() < 1)
         return {
           "Invalid command sub-literal.",
-          " (//give <item/horse>)"};
+          " (//give <item/horse/preset>)"};
 
       const auto& subLiteral = arguments[0];
       const auto characterRecord = _serverInstance.GetDataDirector().GetCharacter(
@@ -365,6 +365,9 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
         {
           character.gifts().emplace_back(giftUid);
         });
+
+        _serverInstance.GetRanchDirector().SendStorageNotification(
+          characterUid, protocol::AcCmdCRRequestStorage::Category::Gifts);
 
         return {
           "Item stored in your gift storage.",
@@ -446,6 +449,9 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
             character.gifts().emplace_back(giftUid);
           });
         }
+
+        _serverInstance.GetRanchDirector().SendStorageNotification(
+          characterUid, protocol::AcCmdCRRequestStorage::Category::Gifts);
 
         return {"Preset gifted. Check your inventory!"};
       }

--- a/src/server/system/ChatSystem.cpp
+++ b/src/server/system/ChatSystem.cpp
@@ -349,11 +349,11 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
         // Create the stored item.
         auto giftUid = data::InvalidUid;
         const auto storedItem = _serverInstance.GetDataDirector().CreateStorageItem();
-        storedItem.Mutable([this, &giftUid, createdItemUid, createdItemTid](data::StorageItem& storedItem)
+        storedItem.Mutable([this, &giftUid, itemCount, createdItemUid, createdItemTid](data::StorageItem& storedItem)
         {
           storedItem.items().emplace_back(createdItemUid);
           storedItem.sender() = "System";
-          storedItem.message() = std::format("Item '{}'", createdItemTid);
+          storedItem.message() = std::format("{}x Item '{}'", itemCount, createdItemTid);
           storedItem.created() = data::Clock::now();
 
           giftUid = storedItem.uid();

--- a/src/server/system/ChatSystem.cpp
+++ b/src/server/system/ChatSystem.cpp
@@ -430,7 +430,7 @@ ChatSystem::ChatSystem(ServerInstance& serverInstance)
             createdItemUid = item.uid();
           });
 
-          // Add the stored item as a gift.
+          // Add the item directly to character's inventory.
           characterRecord.Mutable([createdItemUid](data::Character& character)
           {
             character.items().emplace_back(createdItemUid);

--- a/src/server/system/ChatSystem.cpp
+++ b/src/server/system/ChatSystem.cpp
@@ -51,7 +51,7 @@ std::vector<std::string> CommandManager::HandleCommand(
   catch (const std::exception& x)
   {
     spdlog::error("Exception executing command handler for '{}': {}", literal, x.what());
-    return {"Sever error, contact administrators."};
+    return {"Server error, contact administrators."};
   }
 }
 


### PR DESCRIPTION
- Implements `//give preset` command with hardcoded presets for convenience of new players/devs that nuked server files and need fast inventory setup
- Implements `SendStorageNotification` to send storage notification popup to a client using character UID
- Fixes storage item dao not storing item created timestamp
