### PR TITLE
Implement race skill

### DIFF
--- a/include/libserver/data/DataDefinitions.hpp
+++ b/include/libserver/data/DataDefinitions.hpp
@@ -261,6 +261,27 @@ struct Character
   dao::Field<std::vector<Uid>> housing{};
 
   dao::Field<bool> isRanchLocked{};
+
+  struct Skills
+  {
+    // TODO: confirm this
+    //! Max 2 skill sets per gamemode
+    struct Sets
+    {
+      //! Max 2 skills per skill set
+      struct Set
+      {
+        uint32_t slot1{};
+        uint32_t slot2{};
+      };
+
+      Set set1{};
+      Set set2{};
+    };
+
+    dao::Field<Sets> speed{};
+    dao::Field<Sets> magic{};
+  } skills{};
 };
 
 struct Horse

--- a/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
+++ b/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
@@ -508,8 +508,9 @@ struct League
 
 enum class TeamMode : uint8_t
 {
-  Single = 1,
-  Team = 2
+  FFA = 1, // Multiplayer single
+  Team = 2,
+  Single = 3 // Singleplayer/training
 };
 
 enum class Gamemode : uint32_t

--- a/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
+++ b/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
@@ -512,6 +512,34 @@ enum class TeamMode : uint8_t
   Team = 2
 };
 
+enum class Gamemode : uint32_t
+{
+  Speed = 1,
+  Magic = 2,
+  Unk4 = 4
+};
+
+struct SkillSet
+{
+  //! ID of the set
+  //! 0 - Set 1
+  //! 1 - Set 2
+  uint8_t setId{};
+  //! Either speed (1) or magic (2)
+  Gamemode gamemode{};
+  //! ID of racing skills
+  //! Max 2 skills
+  std::vector<uint32_t> skills{};
+
+  static void Write(
+    const SkillSet& command,
+    SinkStream& stream);
+
+  static void Read(
+    SkillSet& command,
+    SourceStream& stream);
+};
+
 } // namespace server
 
 #endif

--- a/include/libserver/network/command/proto/LobbyMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/LobbyMessageDefinitions.hpp
@@ -1905,6 +1905,32 @@ struct AcCmdCLRequestMountInfoOK
     SourceStream& stream);
 };
 
+struct AcCmdLCSkillCardPresetList
+{
+  uint8_t unk0{};
+  uint8_t unk1{};
+  std::vector<SkillSet> skillSets{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdLCSkillCardPresetList;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdLCSkillCardPresetList& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdLCSkillCardPresetList& command,
+    SourceStream& stream);
+};
+
 } // namespace server::protocol
 
 #endif // LOBBY_MESSAGE_DEFINES_HPP

--- a/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
@@ -446,7 +446,7 @@ struct AcCmdCRStartRace
 
 struct AcCmdCRStartRaceNotify
 {
-  uint8_t gameMode{};
+  Gamemode gameMode{};
   TeamMode teamMode{};
   // this is an oid of a special player
   uint16_t hostOid{};

--- a/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
@@ -2199,6 +2199,31 @@ struct AcCmdRCAddSkillEffect
     SourceStream& stream);
 };
 
+struct AcCmdCRChangeSkillCardPresetID
+{
+  uint8_t setId{};
+  Gamemode gamemode{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRChangeSkillCardPresetID;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdCRChangeSkillCardPresetID& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdCRChangeSkillCardPresetID& command,
+    SourceStream& stream);
+};
+
 } // namespace server::protocol
 
 #endif // RACE_MESSAGE_DEFINES_HPP

--- a/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
@@ -522,21 +522,23 @@ struct AcCmdCRStartRaceNotify
   uint16_t missionId{};
   uint8_t unk12{};
 
-  struct Struct3
+  struct ActiveSkillSet
   {
-    uint8_t unk0{};
+    //! Skill set ID
+    uint8_t setId{};
+    //! Unused TODO: confirm this
     uint32_t unk1{};
-    // List size specified with a byte. Max size 3
-    std::vector<uint16_t> unk2{};
+    //! Skills (including bonus). Max 3 skills
+    std::array<uint32_t, 3> skills{};
 
     static void Write(
-      const Struct3& command,
+      const ActiveSkillSet& command,
       SinkStream& stream);
 
     static void Read(
-      Struct3& command,
+      ActiveSkillSet& command,
       SourceStream& stream);
-  } unk13{};
+  } racerActiveSkillSet{};
 
   uint8_t unk14{};
   //! Carnival (FestivalMissionInfo)
@@ -984,7 +986,7 @@ struct AcCmdRCRaceResultNotify
 
   //! Max 16 entries, short as size
   std::vector<ScoreInfo> scores{};
-  AcCmdCRStartRaceNotify::Struct3 member2{};
+  AcCmdCRStartRaceNotify::ActiveSkillSet racerActiveSkillSet{};
 
   uint32_t member3{};
   uint32_t member4{};

--- a/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
@@ -3596,6 +3596,30 @@ struct AcCmdRCHideAgeNotify
     SourceStream& stream);
 };
 
+struct AcCmdCRChangeSkillCardPreset
+{
+  SkillSet skillSet{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRChangeSkillCardPreset;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdCRChangeSkillCardPreset& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdCRChangeSkillCardPreset& command,
+    SourceStream& stream);
+};
+
 } // namespace server::protocol
 
 #endif // RANCH_MESSAGE_DEFINES_HPP

--- a/include/server/race/RaceDirector.hpp
+++ b/include/server/race/RaceDirector.hpp
@@ -28,6 +28,7 @@
 #include "libserver/network/command/proto/RaceMessageDefinitions.hpp"
 #include "libserver/util/Scheduler.hpp"
 
+#include <random>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -78,6 +79,8 @@ public:
   Config::Race& GetConfig();
 
 private:
+  std::random_device _randomDevice;
+
   struct ClientContext
   {
     data::Uid characterUid{data::InvalidUid};

--- a/include/server/race/RaceDirector.hpp
+++ b/include/server/race/RaceDirector.hpp
@@ -215,6 +215,10 @@ private:
     ClientId clientId,
     const protocol::AcCmdCRChangeMagicTargetCancel& command);
 
+  void HandleChangeSkillCardPresetId(
+    ClientId clientId,
+    const protocol::AcCmdCRChangeSkillCardPresetID& command);
+
   // Note: HandleActivateSkillEffect commented out due to build issues
   // void HandleActivateSkillEffect(
   //   ClientId clientId,

--- a/include/server/ranch/RanchDirector.hpp
+++ b/include/server/ranch/RanchDirector.hpp
@@ -317,9 +317,13 @@ private:
     ClientId clientId,
     const protocol::AcCmdCRHideAge command);
 
-    void HandleStatusPointApply(
+  void HandleStatusPointApply(
     ClientId clientId,
     const protocol::AcCmdCRStatusPointApply command);
+
+  void HandleChangeSkillCardPreset(
+    ClientId clientId,
+    const protocol::AcCmdCRChangeSkillCardPreset command);
 
   //!
   ServerInstance& _serverInstance;

--- a/include/server/tracker/RaceTracker.hpp
+++ b/include/server/tracker/RaceTracker.hpp
@@ -60,6 +60,12 @@ public:
     uint32_t courseTime{};
     std::optional<uint32_t> magicItem{};
     
+    struct ActiveSkillSet
+    {
+      uint8_t setId{};
+      std::array<uint32_t, 3> skills{};
+    } skillSet{};
+    
     // Bolt targeting system
     bool isTargeting{false};
     Oid currentTarget{InvalidEntityOid};

--- a/src/libserver/network/command/proto/LobbyMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/LobbyMessageDefinitions.cpp
@@ -1290,4 +1290,25 @@ void AcCmdCLRequestMountInfoOK::Write(
   }
 }
 
+void AcCmdLCSkillCardPresetList::Read(
+  AcCmdLCSkillCardPresetList& command,
+  SourceStream& stream)
+{
+  throw std::runtime_error("Not implemented.");
+}
+
+void AcCmdLCSkillCardPresetList::Write(
+  const AcCmdLCSkillCardPresetList& command,
+  SinkStream& stream)
+{
+  stream.Write(command.unk0)
+    .Write(command.unk1);
+
+  stream.Write(static_cast<uint8_t>(command.skillSets.size()));
+  for (const auto& skillSet : command.skillSets)
+  {
+    stream.Write(skillSet);
+  }
+}
+
 } // namespace server::protocol

--- a/src/libserver/network/command/proto/RaceMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RaceMessageDefinitions.cpp
@@ -1746,4 +1746,19 @@ void AcCmdRCAddSkillEffect::Read(
     .Read(command.intensity);
 }
 
+void AcCmdCRChangeSkillCardPresetID::Write(
+  const AcCmdCRChangeSkillCardPresetID& command,
+  SinkStream& stream)
+{
+  throw std::runtime_error("Not implemented");
+}
+
+void AcCmdCRChangeSkillCardPresetID::Read(
+  AcCmdCRChangeSkillCardPresetID& command,
+  SourceStream& stream)
+{
+  stream.Read(command.setId)
+    .Read(command.gamemode);
+}
+
 } // namespace server::protocol

--- a/src/libserver/network/command/proto/RaceMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RaceMessageDefinitions.cpp
@@ -422,23 +422,23 @@ void AcCmdCRStartRaceNotify::Struct2::Read(
   throw std::runtime_error("Not implemented.");
 }
 
-void AcCmdCRStartRaceNotify::Struct3::Write(
-  const Struct3& command,
+void AcCmdCRStartRaceNotify::ActiveSkillSet::Write(
+  const ActiveSkillSet& command,
   SinkStream& stream)
 {
-  stream.Write(command.unk0)
+  stream.Write(command.setId)
     .Write(command.unk1);
 
   stream.Write(static_cast<uint8_t>(
-    command.unk2.size()));
-  for (const auto& element : command.unk2)
+    command.skills.size()));
+  for (const auto& element : command.skills)
   {
     stream.Write(element);
   }
 }
 
-void AcCmdCRStartRaceNotify::Struct3::Read(
-  Struct3& command,
+void AcCmdCRStartRaceNotify::ActiveSkillSet::Read(
+  ActiveSkillSet& command,
   SourceStream& stream)
 {
   throw std::runtime_error("Not implemented.");
@@ -477,7 +477,7 @@ void AcCmdCRStartRaceNotify::Write(
 
   stream.Write(command.missionId)
     .Write(command.unk12)
-    .Write(command.unk13);
+    .Write(command.racerActiveSkillSet);
 
   stream.Write(command.unk14)
     .Write(command.carnivalType)
@@ -770,7 +770,7 @@ void AcCmdRCRaceResultNotify::Write(
       .Write(score.member27);
   }
 
-  stream.Write(command.member2);
+  stream.Write(command.racerActiveSkillSet);
 
   stream.Write(command.member3)
     .Write(command.member4);

--- a/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
@@ -2301,5 +2301,19 @@ void AcCmdCRStatusPointApplyCancel::Read(
   // empty
 }
 
+void AcCmdCRChangeSkillCardPreset::Write(
+  const AcCmdCRChangeSkillCardPreset& command,
+  SinkStream& stream)
+{
+  throw std::runtime_error("Not implemented");
+}
+
+void AcCmdCRChangeSkillCardPreset::Read(
+  AcCmdCRChangeSkillCardPreset& command,
+  SourceStream& stream)
+{
+  stream.Read(command.skillSet);
+}
+
 } // namespace server::protocol
 

--- a/src/server/lobby/LoginHandler.cpp
+++ b/src/server/lobby/LoginHandler.cpp
@@ -560,6 +560,30 @@ void LoginHandler::QueueUserLoginAccepted(
     {
       return response;
     });
+
+  protocol::AcCmdLCSkillCardPresetList skillPresetListResponse{
+    .unk0 = 0,
+    .unk1 = 0
+  };
+
+  characterRecord.Immutable([&skillPresetListResponse](const data::Character& character)
+  {
+    const auto& speed = character.skills.speed();
+    const auto& magic = character.skills.magic();
+    skillPresetListResponse.skillSets = {
+      SkillSet{.setId = 0, .gamemode = Gamemode::Speed, .skills = {speed.set1.slot1, speed.set1.slot2}},
+      SkillSet{.setId = 1, .gamemode = Gamemode::Speed, .skills = {speed.set2.slot1, speed.set2.slot2}},
+      SkillSet{.setId = 0, .gamemode = Gamemode::Magic, .skills = {magic.set1.slot1, magic.set1.slot2}},
+      SkillSet{.setId = 1, .gamemode = Gamemode::Magic, .skills = {magic.set2.slot1, magic.set2.slot2}}
+    };
+  });
+
+  _server.QueueCommand<decltype(skillPresetListResponse)>(
+    clientId,
+    [skillPresetListResponse]()
+    {
+      return skillPresetListResponse;
+    });
 }
 
 void LoginHandler::QueueUserCreateNickname(ClientId clientId, const std::string& userName)

--- a/src/server/race/RaceDirector.cpp
+++ b/src/server/race/RaceDirector.cpp
@@ -975,6 +975,22 @@ void RaceDirector::HandleStartRace(
 
         notify.hostOid = racer.oid;
 
+        bool isSpeedOrMagic =
+          notify.gameMode == static_cast<uint8_t>(Gamemode::Speed) ||
+          notify.gameMode == static_cast<uint8_t>(Gamemode::Magic);
+        // Skills only apply for speed single or magic single
+        if (isSpeedOrMagic && notify.teamMode == TeamMode::FFA)
+        {
+          // Notify racer of confirmed selection of skills
+          notify.racerActiveSkillSet.setId = racer.skillSet.setId;
+          // TODO: validate this against level-locked skills
+          assert(notify.racerActiveSkillSet.skills.size() >= racer.skillSet.skills.size());
+          std::copy(
+            racer.skillSet.skills.begin(),
+            racer.skillSet.skills.end(),
+            notify.racerActiveSkillSet.skills.begin());
+        }
+
         _commandServer.QueueCommand<decltype(notify)>(
           roomClientId,
           [notify]()
@@ -2161,10 +2177,47 @@ void RaceDirector::HandleChangeSkillCardPresetId(
   ClientId clientId,
   const protocol::AcCmdCRChangeSkillCardPresetID& command)
 {
-  spdlog::debug("[{}] AcCmdCRChangeSkillCardPresetID: {} {}",
-    clientId,
-    command.setId,
-    static_cast<uint8_t>(command.gamemode));
+  if (command.setId < 0 || command.setId > 2)
+  {
+    // TODO: throw? return?
+    // Calling client requested to change skill preset to something out of range
+    // 0 < setId < 3
+    return;
+  }
+  
+  if (command.gamemode != Gamemode::Speed && command.gamemode != Gamemode::Magic)
+  {
+    // TODO: throw? return?
+    // Gamemode can either be speed (1) or magic (2)
+    return;
+  }
+  
+  const auto& clientContext = _clients[clientId];
+  auto& roomInstance = _roomInstances[clientContext.roomUid];
+  auto& racer = roomInstance.tracker.GetRacer(clientContext.characterUid);
+
+  GetServerInstance().GetDataDirector().GetCharacter(clientContext.characterUid).Immutable(
+    [&racer, &command](const data::Character& character)
+    {
+      // Get skill sets by gamemode
+      const auto& skillSets = 
+        command.gamemode == Gamemode::Speed ? character.skills.speed() :
+        command.gamemode == Gamemode::Magic ? character.skills.magic() :
+        throw std::runtime_error("Invalid gamemode");
+      // Get skill set by setId
+      const auto& skillSet =
+        command.setId == 0 ? skillSets.set1 :
+        command.setId == 1 ? skillSets.set2 :
+        throw std::runtime_error("Invalid skill set ID");
+      // Set racer skill set from record
+      racer.skillSet = {
+        .setId = command.setId,
+        .skills = {skillSet.slot1, skillSet.slot2}
+      };
+    }
+  );
+
+  // No response command
 }
 
 } // namespace server

--- a/src/server/race/RaceDirector.cpp
+++ b/src/server/race/RaceDirector.cpp
@@ -243,6 +243,12 @@ RaceDirector::RaceDirector(ServerInstance& serverInstance)
   //   {
   //     HandleActivateSkillEffect(clientId, message);
   //   });
+
+  _commandServer.RegisterCommandHandler<protocol::AcCmdCRChangeSkillCardPresetID>(
+    [this](ClientId clientId, const auto& message)
+    {
+      HandleChangeSkillCardPresetId(clientId, message);
+    });
 }
 
 void RaceDirector::Initialize()
@@ -2169,5 +2175,14 @@ void RaceDirector::HandleActivateSkillEffect(
 }
 */
 
+void RaceDirector::HandleChangeSkillCardPresetId(
+  ClientId clientId,
+  const protocol::AcCmdCRChangeSkillCardPresetID& command)
+{
+  spdlog::debug("[{}] AcCmdCRChangeSkillCardPresetID: {} {}",
+    clientId,
+    command.setId,
+    static_cast<uint8_t>(command.gamemode));
+}
 
 } // namespace server

--- a/src/server/ranch/RanchDirector.cpp
+++ b/src/server/ranch/RanchDirector.cpp
@@ -330,6 +330,12 @@ RanchDirector::RanchDirector(ServerInstance& serverInstance)
     {
       HandleHideAge(clientId, command);
     });
+
+  _commandServer.RegisterCommandHandler<protocol::AcCmdCRChangeSkillCardPreset>(
+    [this](ClientId clientId, const auto& command)
+    {
+      HandleChangeSkillCardPreset(clientId, command);
+    });
 }
 
 void RanchDirector::Initialize()
@@ -3189,6 +3195,49 @@ void RanchDirector::HandleStatusPointApply(
     [response]()
     {
       return response;
+    });
+}
+
+void RanchDirector::HandleChangeSkillCardPreset(
+  ClientId clientId,
+  const protocol::AcCmdCRChangeSkillCardPreset command)
+{
+  const auto& clientContext = GetClientContext(clientId);
+  if (command.skillSet.setId > 2)
+  {
+    // TODO: character tried to update skill set exceeding range, return?
+    spdlog::warn("Character {} tried to update their skill set {} but character cannot have more than 2 skill sets",
+      clientContext.characterUid, command.skillSet.setId);
+    return;
+  }
+  else if (command.skillSet.skills.size() > 2)
+  {
+    spdlog::warn("Character {} tried to save more skills ({} skills) than a skill set can hold (2 skills)",
+      clientContext.characterUid, command.skillSet.skills.size());
+    return;
+  }
+
+  const auto& characterRecord = GetServerInstance().GetDataDirector().GetCharacter(clientContext.characterUid);
+  characterRecord.Mutable(
+    [&command](data::Character& character)
+    {
+      auto selectSkillSets = [&character](Gamemode gamemode)
+      { 
+        switch (gamemode)
+        {
+          case Gamemode::Magic:
+            return &character.skills.magic();
+          case Gamemode::Speed:
+            return &character.skills.speed();
+          default:
+            throw std::runtime_error("Gamemode is not recognised");
+        }
+      };
+
+      const auto& skillSets = selectSkillSets(command.skillSet.gamemode);
+      auto& skillSet = command.skillSet.setId == 0 ? skillSets->set1 : skillSets->set2;
+      skillSet.slot1 = command.skillSet.skills[0];
+      skillSet.slot2 = command.skillSet.skills[1];
     });
 }
 


### PR DESCRIPTION
Race skills for magic and speed implemented.

- Correctly and strictly stores 2 sets of 2 skills for speed and magic 
- Applies changes to chosen skill set after pre-race countdown and before start race notify
- Sends and loads correct skill set on client in start race notify
- Bonus skill is correctly applied based on speed or magic

- [ ] Look at creating a skill registry instead of hard coding bonus skills
- [ ] Update from upstream and utilise new RoomRegistry refactor changes