### PR TITLE
Implement micro-profiler (#27)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,8 @@ add_library(alicia-libserver STATIC
         src/libserver/util/Locale.cpp
         src/libserver/util/Scheduler.cpp
         src/libserver/util/Stream.cpp
-        src/libserver/util/Util.cpp)
+        src/libserver/util/Util.cpp
+        src/libserver/util/Profiler.cpp)
 target_include_directories(alicia-libserver PUBLIC
         include/)
 target_link_libraries(alicia-libserver PRIVATE

--- a/include/libserver/network/Server.hpp
+++ b/include/libserver/network/Server.hpp
@@ -20,6 +20,7 @@
 #ifndef SERVER_HPP
 #define SERVER_HPP
 
+#include "libserver/util/Profiler.hpp"
 #include "NetworkDefinitions.hpp"
 
 #include <chrono>
@@ -115,6 +116,11 @@ private:
   asio::ip::tcp::socket _socket;
   //! A network event handling interface
   EventHandlerInterface& _networkEventHandler;
+
+  //! Profiler for monitoring async write operations.
+  Profiler _writeProfiler;
+  //! Profiler for monitoring async read operations.
+  Profiler _readProfiler;
 };
 
 //! Server with event-driven acceptor, reads and writes.

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -74,10 +74,10 @@ public:
   ~Profiler() noexcept = default;
 
   //! Begins a timing measurement.
-  void Start();
+  void Start() noexcept;
 
-  //! Ends the current timing measurement and records the elapsed duration.
-  void Stop();
+  /** Ends the current timing measurement and records the elapsed duration. */
+  void Stop() noexcept;
 
   //! Returns a ScopeGuard that times the enclosing scope automatically.
   ScopeGuard Scope();

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -75,8 +75,8 @@ public:
     Profiler & profile;
   };
 
-  Profiler() = default;
-  ~Profiler() = default;
+  Profiler() noexcept = default;
+  ~Profiler() noexcept = default;
 
   /** Begins a timing measurement. */
   void Start();

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -83,7 +83,7 @@ public:
   [[nodiscard]] ScopeGuard Scope() noexcept;
 
   //! Returns the most recently recorded sample duration, or empty if no samples have been recorded.
-  std::optional<Microseconds> Result() const;
+  [[nodiscard]] std::optional<Microseconds> Result() noexcept const;
 
 private:
   using Clock = std::chrono::steady_clock;

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -73,7 +73,7 @@ public:
     ScopeGuard(const ScopeGuard &) = delete;
     ScopeGuard & operator=(const ScopeGuard &) = delete;
 
-    Profiler & profile;
+    Profiler & _profile;
   };
 
   Profiler() noexcept = default;

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -59,7 +59,8 @@ public:
    */
   struct ScopeGuard
   {
-    explicit ScopeGuard(Profiler & profile) : profile(profile)
+    explicit ScopeGuard(Profiler & profile) noexcept 
+      : profile(profile)
     {
       profile.Start();
     }

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -49,7 +49,8 @@ namespace server
 class Profiler
 {
 public:
-  using Microseconds = std::chrono::microseconds;
+  using Clock = std::chrono::steady_clock;
+  using Duration = Clock::duration;
 
   //! RAII wrapper that calls Start() on construction and Stop() on destruction.
   //! Non-copyable but movable.
@@ -87,15 +88,14 @@ public:
   [[nodiscard]] ScopeGuard Scope() noexcept;
 
   //! Returns the most recently recorded sample duration, or empty if no samples have been recorded.
-  [[nodiscard]] std::optional<Microseconds> Result() const noexcept;
+  [[nodiscard]] std::optional<Duration> Result() const noexcept;
 
 private:
-  using Clock = std::chrono::steady_clock;
   using TimePoint = std::chrono::time_point<Clock>;
 
   mutable std::mutex _mutex;
   TimePoint _start{};
-  std::optional<Microseconds> _lastSample;
+  std::optional<Duration> _lastSample;
 };
 
 } // namespace server

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -65,7 +65,7 @@ public:
       profile.Start();
     }
 
-    ~ScopeGuard()
+    ~ScopeGuard() noexcept
     {
       profile.Stop();
     }

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -64,8 +64,10 @@ public:
       _profile.Stop();
     }
 
-    ScopeGuard(const ScopeGuard &) = delete;
-    ScopeGuard & operator=(const ScopeGuard &) = delete;
+    //! Default move constructor.
+    ScopeGuard(ScopeGuard&&) noexcept = default;
+    //! Default move assignment operator.
+    ScopeGuard& operator=(ScopeGuard &&) noexcept = default;
 
     Profiler & _profile;
   };

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -22,8 +22,6 @@
 
 #include <chrono>
 #include <mutex>
-#include <vector>
-#include <numeric>
 #include <optional>
 
 namespace server
@@ -32,8 +30,7 @@ namespace server
 /**
  * A lightweight micro-profiler for measuring operation durations.
  *
- * Collects timing samples in a fixed-size ring buffer and provides
- * basic statistics (average, min, max) over the recorded samples.
+ * Records timing samples using std::chrono::steady_clock.
  * Supports both manual Start()/Stop() calls and RAII-based scoped measurement.
  *
  * @example
@@ -48,7 +45,7 @@ namespace server
  *   // Scoped usage:
  *   { auto guard = profiler.Scope(); doWork(); }
  *
- *   auto avg = profiler.Average();
+ *   auto result = profiler.Result();
  * @endcode
  */
 class Profiler
@@ -78,11 +75,7 @@ public:
     Profiler & profile;
   };
 
-  /**
-   * Constructs the profiler with a ring buffer of the given capacity.
-   * @param capacity Maximum number of samples to retain. Defaults to 1000.
-   */
-  explicit Profiler(std::size_t capacity = 1000);
+  Profiler() = default;
   ~Profiler() = default;
 
   /** Begins a timing measurement. */
@@ -97,25 +90,10 @@ public:
    */
   ScopeGuard Scope();
 
-  /**
-   * @return Average duration across all recorded samples.
+  /** Returns the most recently recorded sample duration, or empty if no samples have been recorded.
+   * @return The most recent sample
    */
-  [[nodiscard]] std::optional<Microseconds> Average() const;
-
-  /**
-   * @return Maximum duration across all recorded samples.
-   */
-  [[nodiscard]] std::optional<Microseconds> Max() const;
-
-  /**
-   * @return Minimum duration across all recorded samples.
-   */
-  [[nodiscard]] std::optional<Microseconds> Min() const;
-
-  /**
-   * @return Number of samples recorded, up to capacity.
-   */
-  [[nodiscard]] std::size_t Count() const;
+  std::optional<Microseconds> Result() const;
 
 private:
 
@@ -124,10 +102,7 @@ private:
 
   mutable std::mutex _mutex;
   TimePoint _start {};
-  std::size_t _count {};
-  std::size_t _capacity {};
-  std::size_t _index {};
-  std::vector<Microseconds> _samples {};
+  std::optional<Microseconds> _lastSample;
 };
 
 } // namespace server

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -56,7 +56,7 @@ public:
     explicit ScopeGuard(Profiler & profile) noexcept
       : _profile(profile)
     {
-      profile.Start();
+      _profile.Start();
     }
 
     ~ScopeGuard() noexcept
@@ -65,7 +65,7 @@ public:
     }
 
     //! Default move constructor.
-    ScopeGuard(ScopeGuard&&) noexcept = default;
+    ScopeGuard(ScopeGuard &&) noexcept = default;
     //! Default move assignment operator.
     ScopeGuard& operator=(ScopeGuard &&) noexcept = default;
 

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -1,21 +1,19 @@
-/**
- * Alicia Server - dedicated server software
- * Copyright (C) 2026 Story Of Alicia
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- **/
+//! Alicia Server - dedicated server software
+//! Copyright (C) 2026 Story Of Alicia
+//!
+//! This program is free software; you can redistribute it and/or modify
+//! it under the terms of the GNU General Public License as published by
+//! the Free Software Foundation; either version 2 of the License, or
+//! (at your option) any later version.
+//!
+//! This program is distributed in the hope that it will be useful,
+//! but WITHOUT ANY WARRANTY; without even the implied warranty of
+//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//! GNU General Public License for more details.
+//!
+//! You should have received a copy of the GNU General Public License along
+//! with this program; if not, write to the Free Software Foundation, Inc.,
+//! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef ALICIA_SERVER_PROFILER_HPP
 #define ALICIA_SERVER_PROFILER_HPP
@@ -27,47 +25,43 @@
 namespace server
 {
 
-/**
- * A lightweight micro-profiler for measuring operation durations.
- *
- * Records timing samples using std::chrono::steady_clock.
- * Supports both manual Start()/Stop() calls and RAII-based scoped measurement.
- *
- * @example
- * @code
- *   Profiler profiler;
- *
- *   // Manual usage:
- *   profiler.Start();
- *   doWork();
- *   profiler.Stop();
- *
- *   // Scoped usage:
- *   { auto guard = profiler.Scope(); doWork(); }
- *
- *   auto result = profiler.Result();
- * @endcode
- */
+//! A lightweight micro-profiler for measuring operation durations.
+//!
+//! Records timing samples using std::chrono::steady_clock.
+//! Supports both manual Start()/Stop() calls and RAII-based scoped measurement.
+//!
+//! @example
+//! @code
+//!   Profiler profiler;
+//!
+//!   // Manual usage:
+//!   profiler.Start();
+//!   doWork();
+//!   profiler.Stop();
+//!
+//!   // Scoped usage:
+//!   { auto guard = profiler.Scope(); doWork(); }
+//!
+//!   auto result = profiler.Result();
+//! @endcode
 class Profiler
 {
 public:
   using Microseconds = std::chrono::microseconds;
 
-  /**
-   * RAII wrapper that calls Start() on construction and Stop() on destruction.
-   * Non-copyable to prevent double-recording.
-   */
+  //! RAII wrapper that calls Start() on construction and Stop() on destruction.
+  //! Non-copyable to prevent double-recording.
   struct ScopeGuard
   {
-    explicit ScopeGuard(Profiler & profile) noexcept 
-      : profile(profile)
+    explicit ScopeGuard(Profiler & profile) noexcept
+      : _profile(profile)
     {
       profile.Start();
     }
 
     ~ScopeGuard() noexcept
     {
-      profile.Stop();
+      _profile.Stop();
     }
 
     ScopeGuard(const ScopeGuard &) = delete;
@@ -79,21 +73,16 @@ public:
   Profiler() noexcept = default;
   ~Profiler() noexcept = default;
 
-  /** Begins a timing measurement. */
+  //! Begins a timing measurement.
   void Start();
 
-  /** Ends the current timing measurement and records the elapsed duration. */
+  //! Ends the current timing measurement and records the elapsed duration.
   void Stop();
 
-  /**
-   * Returns a ScopeGuard that times the enclosing scope automatically.
-   * @return A ScopeGuard bound to this profiler.
-   */
+  //! Returns a ScopeGuard that times the enclosing scope automatically.
   ScopeGuard Scope();
 
-  /** Returns the most recently recorded sample duration, or empty if no samples have been recorded.
-   * @return The most recent sample
-   */
+  //! Returns the most recently recorded sample duration, or empty if no samples have been recorded.
   std::optional<Microseconds> Result() const;
 
 private:

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -80,7 +80,7 @@ public:
   void Stop() noexcept;
 
   //! Returns a ScopeGuard that times the enclosing scope automatically.
-  ScopeGuard Scope();
+  [[nodiscard]] ScopeGuard Scope() noexcept;
 
   //! Returns the most recently recorded sample duration, or empty if no samples have been recorded.
   std::optional<Microseconds> Result() const;

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -1,5 +1,5 @@
 /**
-* Alicia Server - dedicated server software
+ * Alicia Server - dedicated server software
  * Copyright (C) 2026 Story Of Alicia
  *
  * This program is free software; you can redistribute it and/or modify
@@ -55,7 +55,7 @@ public:
   //! Non-copyable but movable.
   struct ScopeGuard
   {
-    explicit ScopeGuard(Profiler & profile) noexcept
+    explicit ScopeGuard(Profiler& profile) noexcept
       : _profile(profile)
     {
       _profile.Start();
@@ -67,10 +67,11 @@ public:
     }
 
     //! Default move constructor.
-    ScopeGuard(ScopeGuard &&) noexcept = default;
-    ScopeGuard & operator=(ScopeGuard &&) noexcept = default;
+    ScopeGuard(ScopeGuard&&) noexcept = default;
+    //! Default move assignment operator.
+    ScopeGuard& operator=(ScopeGuard&&) noexcept = default;
 
-    Profiler & _profile;
+    Profiler& _profile;
   };
 
   Profiler() noexcept = default;
@@ -93,7 +94,7 @@ private:
   using TimePoint = std::chrono::time_point<Clock>;
 
   mutable std::mutex _mutex;
-  TimePoint _start {};
+  TimePoint _start{};
   std::optional<Microseconds> _lastSample;
 };
 

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -76,14 +76,14 @@ public:
   //! Begins a timing measurement.
   void Start() noexcept;
 
-  /** Ends the current timing measurement and records the elapsed duration. */
+  //! Ends the current timing measurement and records the elapsed duration.
   void Stop() noexcept;
 
   //! Returns a ScopeGuard that times the enclosing scope automatically.
   [[nodiscard]] ScopeGuard Scope() noexcept;
 
   //! Returns the most recently recorded sample duration, or empty if no samples have been recorded.
-  [[nodiscard]] std::optional<Microseconds> Result() noexcept const;
+  [[nodiscard]] std::optional<Microseconds> Result() const noexcept;
 
 private:
   using Clock = std::chrono::steady_clock;

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -1,19 +1,21 @@
-//! Alicia Server - dedicated server software
-//! Copyright (C) 2026 Story Of Alicia
-//!
-//! This program is free software; you can redistribute it and/or modify
-//! it under the terms of the GNU General Public License as published by
-//! the Free Software Foundation; either version 2 of the License, or
-//! (at your option) any later version.
-//!
-//! This program is distributed in the hope that it will be useful,
-//! but WITHOUT ANY WARRANTY; without even the implied warranty of
-//! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//! GNU General Public License for more details.
-//!
-//! You should have received a copy of the GNU General Public License along
-//! with this program; if not, write to the Free Software Foundation, Inc.,
-//! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+/**
+* Alicia Server - dedicated server software
+ * Copyright (C) 2026 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
 
 #ifndef ALICIA_SERVER_PROFILER_HPP
 #define ALICIA_SERVER_PROFILER_HPP
@@ -50,7 +52,7 @@ public:
   using Microseconds = std::chrono::microseconds;
 
   //! RAII wrapper that calls Start() on construction and Stop() on destruction.
-  //! Non-copyable to prevent double-recording.
+  //! Non-copyable but movable.
   struct ScopeGuard
   {
     explicit ScopeGuard(Profiler & profile) noexcept
@@ -66,8 +68,7 @@ public:
 
     //! Default move constructor.
     ScopeGuard(ScopeGuard &&) noexcept = default;
-    //! Default move assignment operator.
-    ScopeGuard& operator=(ScopeGuard &&) noexcept = default;
+    ScopeGuard & operator=(ScopeGuard &&) noexcept = default;
 
     Profiler & _profile;
   };

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -1,0 +1,135 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2024 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef ALICIA_SERVER_PROFILER_HPP
+#define ALICIA_SERVER_PROFILER_HPP
+
+#include <chrono>
+#include <mutex>
+#include <vector>
+#include <numeric>
+#include <optional>
+
+namespace server
+{
+
+/**
+ * A lightweight micro-profiler for measuring operation durations.
+ *
+ * Collects timing samples in a fixed-size ring buffer and provides
+ * basic statistics (average, min, max) over the recorded samples.
+ * Supports both manual Start()/Stop() calls and RAII-based scoped measurement.
+ *
+ * @example
+ * @code
+ *   Profiler profiler;
+ *
+ *   // Manual usage:
+ *   profiler.Start();
+ *   doWork();
+ *   profiler.Stop();
+ *
+ *   // Scoped usage:
+ *   { auto guard = profiler.Scope(); doWork(); }
+ *
+ *   auto avg = profiler.Average();
+ * @endcode
+ */
+class Profiler
+{
+public:
+  using Microseconds = std::chrono::microseconds;
+
+  /**
+   * RAII wrapper that calls Start() on construction and Stop() on destruction.
+   * Non-copyable to prevent double-recording.
+   */
+  struct ScopeGuard
+  {
+    explicit ScopeGuard(Profiler & profile) : profile(profile)
+    {
+      profile.Start();
+    }
+
+    ~ScopeGuard()
+    {
+      profile.Stop();
+    }
+
+    ScopeGuard(const ScopeGuard &) = delete;
+    ScopeGuard & operator=(const ScopeGuard &) = delete;
+
+    Profiler & profile;
+  };
+
+  /**
+   * Constructs the profiler with a ring buffer of the given capacity.
+   * @param capacity Maximum number of samples to retain. Defaults to 1000.
+   */
+  explicit Profiler(std::size_t capacity = 1000);
+  ~Profiler() = default;
+
+  /** Begins a timing measurement. */
+  void Start();
+
+  /** Ends the current timing measurement and records the elapsed duration. */
+  void Stop();
+
+  /**
+   * Returns a ScopeGuard that times the enclosing scope automatically.
+   * @return A ScopeGuard bound to this profiler.
+   */
+  ScopeGuard Scope();
+
+  /**
+   * @return Average duration across all recorded samples.
+   */
+  [[nodiscard]] std::optional<Microseconds> Average() const;
+
+  /**
+   * @return Maximum duration across all recorded samples.
+   */
+  [[nodiscard]] std::optional<Microseconds> Max() const;
+
+  /**
+   * @return Minimum duration across all recorded samples.
+   */
+  [[nodiscard]] std::optional<Microseconds> Min() const;
+
+  /**
+   * @return Number of samples recorded, up to capacity.
+   */
+  [[nodiscard]] std::size_t Count() const;
+
+private:
+
+  using Clock = std::chrono::steady_clock;
+  using TimePoint = std::chrono::time_point<Clock>;
+
+  mutable std::mutex _mutex;
+  TimePoint _start {};
+  std::size_t _count {};
+  std::size_t _capacity {};
+  std::size_t _index {};
+  std::vector<Microseconds> _samples {};
+};
+
+} // namespace server
+
+#endif // ALICIA_SERVER_PROFILER_HPP

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -97,7 +97,6 @@ public:
   std::optional<Microseconds> Result() const;
 
 private:
-
   using Clock = std::chrono::steady_clock;
   using TimePoint = std::chrono::time_point<Clock>;
 

--- a/include/libserver/util/Profiler.hpp
+++ b/include/libserver/util/Profiler.hpp
@@ -1,6 +1,6 @@
 /**
  * Alicia Server - dedicated server software
- * Copyright (C) 2024 Story Of Alicia
+ * Copyright (C) 2026 Story Of Alicia
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/libserver/network/Server.cpp
+++ b/src/libserver/network/Server.cpp
@@ -18,7 +18,6 @@
  **/
 
 #include "libserver/network/Server.hpp"
-
 #include "libserver/util/Deferred.hpp"
 
 #include <cassert>
@@ -138,6 +137,7 @@ void Client::WriteLoop() noexcept
   _isSending.store(true, std::memory_order::release);
 
   // Asynchronously write the data to the socket.
+  _writeProfiler.Start();
   _socket.async_write_some(
     _writeBuffer.data(),
     [clientPtr = this->shared_from_this()](const boost::system::error_code& error, const std::size_t size)
@@ -175,6 +175,7 @@ void Client::WriteLoop() noexcept
       }
 
       clientPtr->_isSending.store(false, std::memory_order::release);
+      clientPtr->_writeProfiler.Stop();
       clientPtr->WriteLoop();
     });
 }
@@ -184,6 +185,7 @@ void Client::ReadLoop() noexcept
   if (not _shouldRun.load(std::memory_order::acquire))
     return;
 
+  _readProfiler.Start();
   _socket.async_read_some(
     _readBuffer.prepare(1024),
     [clientPtr = this->shared_from_this()](boost::system::error_code error, std::size_t size)
@@ -218,6 +220,7 @@ void Client::ReadLoop() noexcept
         clientPtr->_readBuffer.consume(consumedBytes);
 
         // Continue the read loop.
+        clientPtr->_readProfiler.Stop();
         clientPtr->ReadLoop();
       }
       catch (const std::exception& x)

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -21,6 +21,7 @@
 
 namespace server
 {
+
 void Profiler::Start()
 {
   std::scoped_lock lock(_mutex);

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -23,6 +23,8 @@ namespace server
 {
 void Profiler::Start()
 {
+  std::scoped_lock lock(_mutex);
+
   _start = Clock::now();
 }
 

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -33,7 +33,7 @@ void Profiler::Stop() noexcept
 {
   std::scoped_lock lock(_mutex);
 
-  _lastSample = std::chrono::duration_cast<Microseconds>(Clock::now() - _start);
+  _lastSample = Clock::now() - _start;
 }
 
 Profiler::ScopeGuard Profiler::Scope() noexcept
@@ -41,7 +41,7 @@ Profiler::ScopeGuard Profiler::Scope() noexcept
   return ScopeGuard(*this);
 }
 
-std::optional<Profiler::Microseconds> Profiler::Result() const noexcept
+std::optional<Profiler::Duration> Profiler::Result() const noexcept
 {
   std::scoped_lock lock(_mutex);
   return _lastSample;

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -48,4 +48,5 @@ std::optional<Profiler::Microseconds> Profiler::Result() const
   std::scoped_lock lock(_mutex);
   return _lastSample;
 }
+
 } // namespace server

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -48,4 +48,5 @@ std::optional<Profiler::Microseconds> Profiler::Result() const noexcept
 }
 
 
+
 } // namespace server

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -21,12 +21,6 @@
 
 namespace server
 {
-Profiler::Profiler(std::size_t capacity)
-  : _capacity(capacity)
-{
-  _samples.resize(capacity);
-}
-
 void Profiler::Start()
 {
   _start = Clock::now();
@@ -38,9 +32,7 @@ void Profiler::Stop()
 
   std::scoped_lock lock(_mutex);
 
-  _samples.at(_index) = duration;
-  _index = (_index + 1) % _capacity;
-  _count = std::min(_count + 1, _capacity);
+  _lastSample = duration;
 }
 
 Profiler::ScopeGuard Profiler::Scope()
@@ -48,45 +40,9 @@ Profiler::ScopeGuard Profiler::Scope()
   return ScopeGuard(*this);
 }
 
-std::optional<Profiler::Microseconds> Profiler::Average() const
+std::optional<Profiler::Microseconds> Profiler::Result() const
 {
   std::scoped_lock lock(_mutex);
-
-  if (_count == 0)
-    return {};
-
-  return std::reduce(_samples.begin(),
-           _samples.begin() +
-             static_cast<std::ptrdiff_t>(std::min(_count, _capacity)),
-           Microseconds{}) /
-         _count;
-}
-
-std::optional<Profiler::Microseconds> Profiler::Max() const
-{
-  std::scoped_lock lock(_mutex);
-
-  if (_count == 0)
-    return {};
-  return *std::max_element(_samples.begin(),
-    _samples.begin() +
-      static_cast<std::ptrdiff_t>(std::min(_count, _capacity)));
-}
-
-std::optional<Profiler::Microseconds> Profiler::Min() const
-{
-  std::scoped_lock lock(_mutex);
-
-  if (_count == 0)
-    return {};
-  return *std::min_element(_samples.begin(),
-    _samples.begin() +
-      static_cast<std::ptrdiff_t>(std::min(_count, _capacity)));
-}
-
-std::size_t Profiler::Count() const
-{
-  std::scoped_lock lock(_mutex);
-  return _count;
+  return _lastSample;
 }
 } // namespace server

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -1,0 +1,92 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2024 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#include "libserver/util/Profiler.hpp"
+
+namespace server
+{
+Profiler::Profiler(std::size_t capacity)
+  : _capacity(capacity)
+{
+  _samples.resize(capacity);
+}
+
+void Profiler::Start()
+{
+  _start = Clock::now();
+}
+
+void Profiler::Stop()
+{
+  const auto duration = std::chrono::duration_cast<Microseconds>(Clock::now() - _start);
+
+  std::scoped_lock lock(_mutex);
+
+  _samples.at(_index) = duration;
+  _index = (_index + 1) % _capacity;
+  _count = std::min(_count + 1, _capacity);
+}
+
+Profiler::ScopeGuard Profiler::Scope()
+{
+  return ScopeGuard(*this);
+}
+
+std::optional<Profiler::Microseconds> Profiler::Average() const
+{
+  std::scoped_lock lock(_mutex);
+
+  if (_count == 0)
+    return {};
+
+  return std::reduce(_samples.begin(),
+           _samples.begin() +
+             static_cast<std::ptrdiff_t>(std::min(_count, _capacity)),
+           Microseconds{}) /
+         _count;
+}
+
+std::optional<Profiler::Microseconds> Profiler::Max() const
+{
+  std::scoped_lock lock(_mutex);
+
+  if (_count == 0)
+    return {};
+  return *std::max_element(_samples.begin(),
+    _samples.begin() +
+      static_cast<std::ptrdiff_t>(std::min(_count, _capacity)));
+}
+
+std::optional<Profiler::Microseconds> Profiler::Min() const
+{
+  std::scoped_lock lock(_mutex);
+
+  if (_count == 0)
+    return {};
+  return *std::min_element(_samples.begin(),
+    _samples.begin() +
+      static_cast<std::ptrdiff_t>(std::min(_count, _capacity)));
+}
+
+std::size_t Profiler::Count() const
+{
+  std::scoped_lock lock(_mutex);
+  return _count;
+}
+} // namespace server

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -47,4 +47,5 @@ std::optional<Profiler::Microseconds> Profiler::Result() const noexcept
   return _lastSample;
 }
 
+
 } // namespace server

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -22,28 +22,26 @@
 namespace server
 {
 
-void Profiler::Start()
+void Profiler::Start() noexcept
 {
   std::scoped_lock lock(_mutex);
 
   _start = Clock::now();
 }
 
-void Profiler::Stop()
+void Profiler::Stop() noexcept
 {
-  const auto duration = std::chrono::duration_cast<Microseconds>(Clock::now() - _start);
-
   std::scoped_lock lock(_mutex);
 
-  _lastSample = duration;
+  _lastSample = std::chrono::duration_cast<Microseconds>(Clock::now() - _start);
 }
 
-Profiler::ScopeGuard Profiler::Scope()
+Profiler::ScopeGuard Profiler::Scope() noexcept
 {
   return ScopeGuard(*this);
 }
 
-std::optional<Profiler::Microseconds> Profiler::Result() const
+std::optional<Profiler::Microseconds> Profiler::Result() const noexcept
 {
   std::scoped_lock lock(_mutex);
   return _lastSample;

--- a/src/libserver/util/Profiler.cpp
+++ b/src/libserver/util/Profiler.cpp
@@ -1,6 +1,6 @@
 /**
  * Alicia Server - dedicated server software
- * Copyright (C) 2024 Story Of Alicia
+ * Copyright (C) 2026 Story Of Alicia
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,12 @@ target_sources(util_test_alicia_shop_time PRIVATE
 target_link_libraries(util_test_alicia_shop_time
         PRIVATE project-properties alicia-libserver)
 
+add_executable(util_test_profiler)
+target_sources(util_test_profiler PRIVATE
+        src/util/TestProfiler.cpp)
+target_link_libraries(util_test_profiler
+        PRIVATE project-properties alicia-libserver)
+
 add_executable(race_test_p2did_pool)
 target_sources(race_test_p2did_pool PRIVATE
         src/race/TestP2dIdPool.cpp)
@@ -41,5 +47,6 @@ add_test(NAME UtilTestStream COMMAND util_test_stream)
 add_test(NAME UtilTestScheduler COMMAND util_test_scheduler)
 add_test(NAME UtilTestLocale COMMAND util_test_locale)
 add_test(NAME UtilTestAliciaShopTime COMMAND util_test_alicia_shop_time)
+add_test(NAME UtilTestProfiler COMMAND util_test_profiler)
 add_test(NAME RaceTestP2dIdPool COMMAND race_test_p2did_pool)
 

--- a/tests/src/util/TestProfiler.cpp
+++ b/tests/src/util/TestProfiler.cpp
@@ -70,7 +70,6 @@ void TestScopeGuardOnException()
   assert(profiler.Result().value().count() > 0 && "ScopeGuard duration should be valid after exception");
 }
 
-
 } // namespace
 
 int main()

--- a/tests/src/util/TestProfiler.cpp
+++ b/tests/src/util/TestProfiler.cpp
@@ -1,0 +1,145 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2024 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#include <libserver/util/Profiler.hpp>
+
+#include <cassert>
+#include <thread>
+
+namespace
+{
+
+void TestNoSamples()
+{
+  server::Profiler profiler;
+
+  assert(profiler.Count() == 0 && "Count should be zero with no samples");
+  assert(not profiler.Average().has_value() && "Average should be empty with no samples");
+  assert(not profiler.Min().has_value() && "Min should be empty with no samples");
+  assert(not profiler.Max().has_value() && "Max should be empty with no samples");
+}
+
+void TestSingleSample()
+{
+  server::Profiler profiler;
+
+  profiler.Start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  profiler.Stop();
+
+  assert(profiler.Count() == 1 && "Count should be one after a single sample");
+  assert(profiler.Average().has_value() && "Average should have a value after a sample");
+  assert(profiler.Average().value().count() > 0 && "Average duration should be greater than zero");
+  assert(profiler.Min() == profiler.Max() && "Min and Max should be equal with one sample");
+}
+
+void TestMultipleSamples()
+{
+  server::Profiler profiler;
+
+  for (int i = 0; i < 5; ++i)
+  {
+    profiler.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    profiler.Stop();
+  }
+
+  assert(profiler.Count() == 5 && "Count should match number of recorded samples");
+  assert(profiler.Min().value() <= profiler.Average().value() && "Min should be less than or equal to Average");
+  assert(profiler.Average().value() <= profiler.Max().value() && "Average should be less than or equal to Max");
+}
+
+void TestScopeGuard()
+{
+  server::Profiler profiler;
+
+  {
+    auto guard = profiler.Scope();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  assert(profiler.Count() == 1 && "ScopeGuard should record exactly one sample");
+  assert(profiler.Average().value().count() > 0 && "ScopeGuard sample duration should be greater than zero");
+}
+
+void TestRingBufferWraparound()
+{
+  constexpr std::size_t Capacity = 5;
+  server::Profiler profiler(Capacity);
+
+  // Record more samples than the capacity.
+  for (int i = 0; i < 10; ++i)
+  {
+    profiler.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    profiler.Stop();
+  }
+
+  // Count should be capped at capacity.
+  assert(profiler.Count() == Capacity && "Count should not exceed ring buffer capacity");
+}
+
+void TestCustomCapacity()
+{
+  constexpr std::size_t Capacity = 3;
+  server::Profiler profiler(Capacity);
+
+  for (int i = 0; i < 3; ++i)
+  {
+    profiler.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    profiler.Stop();
+  }
+
+  assert(profiler.Count() == Capacity && "Count should match custom capacity when full");
+  assert(profiler.Average().has_value() && "Average should have a value when buffer is full");
+  assert(profiler.Min().has_value() && "Min should have a value when buffer is full");
+  assert(profiler.Max().has_value() && "Max should have a value when buffer is full");
+}
+
+void TestMinMaxOrdering()
+{
+  server::Profiler profiler;
+
+  // Short sample.
+  profiler.Start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  profiler.Stop();
+
+  // Longer sample.
+  profiler.Start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  profiler.Stop();
+
+  assert(profiler.Count() == 2 && "Count should be two after two samples");
+  assert(profiler.Min().value() < profiler.Max().value() && "Min should be less than Max with different durations");
+}
+
+} // namespace
+
+int main()
+{
+  TestNoSamples();
+  TestSingleSample();
+  TestMultipleSamples();
+  TestScopeGuard();
+  TestRingBufferWraparound();
+  TestCustomCapacity();
+  TestMinMaxOrdering();
+}

--- a/tests/src/util/TestProfiler.cpp
+++ b/tests/src/util/TestProfiler.cpp
@@ -78,6 +78,24 @@ void TestScopeGuard()
   assert(profiler.Average().value().count() > 0 && "ScopeGuard sample duration should be greater than zero");
 }
 
+void TestScopeGuardOnException()
+{
+  server::Profiler profiler;
+
+  try
+  {
+    auto guard = profiler.Scope();
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    throw std::runtime_error("test");
+  }
+  catch (...)
+  {
+  }
+
+  assert(profiler.Count() == 1 && "ScopeGuard should record a sample even when an exception is thrown");
+  assert(profiler.Average().value().count() > 0 && "ScopeGuard duration should be valid after exception");
+}
+
 void TestRingBufferWraparound()
 {
   constexpr std::size_t Capacity = 5;
@@ -139,6 +157,7 @@ int main()
   TestSingleSample();
   TestMultipleSamples();
   TestScopeGuard();
+  TestScopeGuardOnException();
   TestRingBufferWraparound();
   TestCustomCapacity();
   TestMinMaxOrdering();

--- a/tests/src/util/TestProfiler.cpp
+++ b/tests/src/util/TestProfiler.cpp
@@ -28,41 +28,17 @@ namespace
 void TestNoSamples()
 {
   server::Profiler profiler;
-
-  assert(profiler.Count() == 0 && "Count should be zero with no samples");
-  assert(not profiler.Average().has_value() && "Average should be empty with no samples");
-  assert(not profiler.Min().has_value() && "Min should be empty with no samples");
-  assert(not profiler.Max().has_value() && "Max should be empty with no samples");
+  assert(not profiler.Result().has_value() && "Result should be empty with no samples");
 }
 
-void TestSingleSample()
+void TestStartStop()
 {
   server::Profiler profiler;
-
   profiler.Start();
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
   profiler.Stop();
-
-  assert(profiler.Count() == 1 && "Count should be one after a single sample");
-  assert(profiler.Average().has_value() && "Average should have a value after a sample");
-  assert(profiler.Average().value().count() > 0 && "Average duration should be greater than zero");
-  assert(profiler.Min() == profiler.Max() && "Min and Max should be equal with one sample");
-}
-
-void TestMultipleSamples()
-{
-  server::Profiler profiler;
-
-  for (int i = 0; i < 5; ++i)
-  {
-    profiler.Start();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    profiler.Stop();
-  }
-
-  assert(profiler.Count() == 5 && "Count should match number of recorded samples");
-  assert(profiler.Min().value() <= profiler.Average().value() && "Min should be less than or equal to Average");
-  assert(profiler.Average().value() <= profiler.Max().value() && "Average should be less than or equal to Max");
+  assert(profiler.Result().has_value() && "Result should have a value after Stop");
+  assert(profiler.Result().value().count() > 0 && "Duration should be greater than zero");
 }
 
 void TestScopeGuard()
@@ -74,8 +50,7 @@ void TestScopeGuard()
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
-  assert(profiler.Count() == 1 && "ScopeGuard should record exactly one sample");
-  assert(profiler.Average().value().count() > 0 && "ScopeGuard sample duration should be greater than zero");
+  assert(profiler.Result().value().count() > 0 && "ScopeGuard sample duration should be greater than zero");
 }
 
 void TestScopeGuardOnException()
@@ -92,73 +67,16 @@ void TestScopeGuardOnException()
   {
   }
 
-  assert(profiler.Count() == 1 && "ScopeGuard should record a sample even when an exception is thrown");
-  assert(profiler.Average().value().count() > 0 && "ScopeGuard duration should be valid after exception");
+  assert(profiler.Result().value().count() > 0 && "ScopeGuard duration should be valid after exception");
 }
 
-void TestRingBufferWraparound()
-{
-  constexpr std::size_t Capacity = 5;
-  server::Profiler profiler(Capacity);
-
-  // Record more samples than the capacity.
-  for (int i = 0; i < 10; ++i)
-  {
-    profiler.Start();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    profiler.Stop();
-  }
-
-  // Count should be capped at capacity.
-  assert(profiler.Count() == Capacity && "Count should not exceed ring buffer capacity");
-}
-
-void TestCustomCapacity()
-{
-  constexpr std::size_t Capacity = 3;
-  server::Profiler profiler(Capacity);
-
-  for (int i = 0; i < 3; ++i)
-  {
-    profiler.Start();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    profiler.Stop();
-  }
-
-  assert(profiler.Count() == Capacity && "Count should match custom capacity when full");
-  assert(profiler.Average().has_value() && "Average should have a value when buffer is full");
-  assert(profiler.Min().has_value() && "Min should have a value when buffer is full");
-  assert(profiler.Max().has_value() && "Max should have a value when buffer is full");
-}
-
-void TestMinMaxOrdering()
-{
-  server::Profiler profiler;
-
-  // Short sample.
-  profiler.Start();
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  profiler.Stop();
-
-  // Longer sample.
-  profiler.Start();
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  profiler.Stop();
-
-  assert(profiler.Count() == 2 && "Count should be two after two samples");
-  assert(profiler.Min().value() < profiler.Max().value() && "Min should be less than Max with different durations");
-}
 
 } // namespace
 
 int main()
 {
   TestNoSamples();
-  TestSingleSample();
-  TestMultipleSamples();
+  TestStartStop();
   TestScopeGuard();
   TestScopeGuardOnException();
-  TestRingBufferWraparound();
-  TestCustomCapacity();
-  TestMinMaxOrdering();
 }

--- a/tests/src/util/TestProfiler.cpp
+++ b/tests/src/util/TestProfiler.cpp
@@ -1,6 +1,6 @@
 /**
  * Alicia Server - dedicated server software
- * Copyright (C) 2024 Story Of Alicia
+ * Copyright (C) 2026 Story Of Alicia
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Closes #27

Implements a micro-profiler using `std::chrono::steady_clock`.

- `Profiler` class with `Start()`/`Stop()` for manual timing and a RAII `ScopeGuard` for scoped measurement
- `Result()` returns the most recent sample duration
- Thread-safe via `std::mutex`
- Instrumented `Client::WriteLoop()` and `Client::ReadLoop()` in `Server.cpp`
- Unit tests added

Initially went a bit overboard with ring buffers and statistics methods - scaled it back per feedback to keep the profiler focused on measurement and leave stats to the collecting system.