### PR TITLE
Racer positional magic (source of truth from libconfig)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ add_executable(alicia-server
         src/server/messenger/MessengerDirector.cpp
         src/server/race/RaceInstance.cpp
         src/server/race/RaceNetworkHandler.cpp
+        src/server/race/magic/MagicConfig.cpp
+        src/server/race/magic/MagicSelector.cpp
         src/server/ranch/RanchDirector.cpp
         src/server/room/Room.cpp
         src/server/system/ChatSystem.cpp

--- a/include/server/race/magic/MagicConfig.hpp
+++ b/include/server/race/magic/MagicConfig.hpp
@@ -1,0 +1,200 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2026 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef ALICIA_SERVER_RACE_MAGIC_CONFIG_HPP
+#define ALICIA_SERVER_RACE_MAGIC_CONFIG_HPP
+
+#include "MagicTypes.hpp"
+
+namespace server::magic
+{
+
+// ============================================================================
+// MAGIC CONFIGURATION
+// Static data loaded from XML config files (MagicAllocInfo, MagicGroupRatio, etc.)
+// ============================================================================
+
+class MagicConfig
+{
+public:
+  // Singleton access
+  static const MagicConfig& GetInstance()
+  {
+    static MagicConfig instance;
+    return instance;
+  }
+
+  // Get allocation rule for a magic type
+  const AllocationRule* GetAllocationRule(MagicType type) const;
+
+  // Get group ratio for a magic group
+  const GroupRatio* GetGroupRatio(MagicGroup group) const;
+
+  // Get slot ratio for a magic type
+  const SlotRatio* GetSlotRatio(MagicType type) const;
+
+  // Get team modifier for a group and lead status
+  const TeamModifier* GetTeamModifier(MagicGroup group, bool isLeading) const;
+
+  // Map magic type to group
+  MagicGroup GetGroupForType(MagicType type) const;
+
+  // Map basic type to group
+  MagicGroup GetGroupForBasicType(BasicType basicType) const;
+
+  // Determine primary group for a rank
+  MagicGroup GetPrimaryGroupForRank(uint32_t rank) const;
+
+  // Get all magic types
+  const std::vector<MagicType>& GetAllMagicTypes() const;
+
+  // Get all magic types valid for a given context
+  std::vector<MagicType> GetValidTypesForContext(const RaceContext& context) const;
+
+private:
+  MagicConfig();
+  MagicConfig(const MagicConfig&) = delete;
+  MagicConfig& operator=(const MagicConfig&) = delete;
+
+  // Initialize all static data
+  void InitializeAllocationRules();
+  void InitializeGroupRatios();
+  void InitializeSlotRatios();
+  void InitializeTeamModifiers();
+  void InitializeTypeMappings();
+
+  // ========================================================================
+  // STATIC DATA FROM XML FILES
+  // ========================================================================
+
+  // All magic types in the game
+  std::vector<MagicType> allMagicTypes_;
+
+  // MagicAllocInfo (Table 216): Allocation rules per magic type
+  std::array<AllocationRule, 26> allocationRules_; // Indexed by MagicType
+
+  // MagicGroupRatio (Table 214): Group probabilities by rank
+  std::array<GroupRatio, 8> groupRatios_; // Indexed by MagicGroup
+
+  // MagicSlotRatio (Table 199): Slot probabilities by rank
+  std::array<SlotRatio, 26> slotRatios_; // Indexed by MagicType
+
+  // MagicGroupTeamModifier (Table 270): Dynamic modifiers
+  std::array<std::array<TeamModifier, 2>, 8> teamModifiers_;
+  // [group][isLeading] -> TeamModifier
+
+  // Type to group mapping
+  std::array<MagicGroup, 26> typeToGroup_;      // [MagicType] -> MagicGroup
+  std::array<MagicGroup, 25> basicTypeToGroup_; // [BasicType] -> MagicGroup
+};
+
+// Inline implementations
+inline const AllocationRule* MagicConfig::GetAllocationRule(MagicType type) const
+{
+  uint32_t index = ToUnderlying(type);
+  if (index < allocationRules_.size())
+  {
+    return &allocationRules_[index];
+  }
+  return nullptr;
+}
+
+inline const GroupRatio* MagicConfig::GetGroupRatio(MagicGroup group) const
+{
+  uint32_t index = static_cast<uint32_t>(group);
+  if (index < groupRatios_.size())
+  {
+    return &groupRatios_[index];
+  }
+  return nullptr;
+}
+
+inline const SlotRatio* MagicConfig::GetSlotRatio(MagicType type) const
+{
+  uint32_t index = ToUnderlying(type);
+  if (index < slotRatios_.size())
+  {
+    return &slotRatios_[index];
+  }
+  return nullptr;
+}
+
+inline const TeamModifier* MagicConfig::GetTeamModifier(MagicGroup group, bool isLeading) const
+{
+  uint32_t g = static_cast<uint32_t>(group);
+  uint32_t l = isLeading ? 1 : 0;
+  if (g < teamModifiers_.size() && l < teamModifiers_[g].size())
+  {
+    return &teamModifiers_[g][l];
+  }
+  return nullptr;
+}
+
+inline MagicGroup MagicConfig::GetGroupForType(MagicType type) const
+{
+  uint32_t index = ToUnderlying(type);
+  if (index < typeToGroup_.size())
+  {
+    return typeToGroup_[index];
+  }
+  return MagicGroup::Invalid;
+}
+
+inline MagicGroup MagicConfig::GetGroupForBasicType(BasicType basicType) const
+{
+  uint32_t index = static_cast<uint32_t>(basicType);
+  if (index < basicTypeToGroup_.size())
+  {
+    return basicTypeToGroup_[index];
+  }
+  return MagicGroup::Invalid;
+}
+
+inline MagicGroup MagicConfig::GetPrimaryGroupForRank(uint32_t rank) const
+{
+  if (rank < 1 || rank > 8)
+    return MagicGroup::Invalid;
+
+  // Determine primary group based on MagicGroupRatio table
+  // For each group, check the weight at this rank
+  // Return the group with highest weight
+  MagicGroup bestGroup = MagicGroup::Invalid;
+  uint32_t bestWeight = 0;
+
+  for (uint32_t g = 1; g < static_cast<uint32_t>(MagicGroup::MaxGroups); ++g)
+  {
+    const auto* ratio = GetGroupRatio(static_cast<MagicGroup>(g));
+    if (ratio && ratio->rankWeights[rank - 1] > bestWeight)
+    {
+      bestWeight = ratio->rankWeights[rank - 1];
+      bestGroup = static_cast<MagicGroup>(g);
+    }
+  }
+
+  return bestGroup;
+}
+
+inline const std::vector<MagicType>& MagicConfig::GetAllMagicTypes() const
+{
+  return allMagicTypes_;
+}
+
+} // namespace server::magic
+
+#endif // ALICIA_SERVER_RACE_MAGIC_CONFIG_HPP

--- a/include/server/race/magic/MagicConfig.hpp
+++ b/include/server/race/magic/MagicConfig.hpp
@@ -22,14 +22,11 @@
 
 #include "MagicTypes.hpp"
 
-namespace server::magic
+namespace server::race::magic
 {
 
-// ============================================================================
-// MAGIC CONFIGURATION
-// Static data loaded from XML config files (MagicAllocInfo, MagicGroupRatio, etc.)
-// ============================================================================
-
+//! Magic Configuration
+//! Static data loaded from XML config files (MagicAllocInfo, MagicGroupRatio, etc.)
 class MagicConfig
 {
 public:
@@ -82,9 +79,7 @@ private:
   void InitializeTeamModifiers();
   void InitializeTypeMappings();
 
-  // ========================================================================
-  // STATIC DATA FROM XML FILES
-  // ========================================================================
+  //! Static data from tables in XML config
 
   // All magic types in the game
   std::vector<MagicType> allMagicTypes_;
@@ -223,6 +218,6 @@ inline const std::vector<MagicType>& MagicConfig::GetAllMagicTypes() const
   return allMagicTypes_;
 }
 
-} // namespace server::magic
+} // namespace server::race::magic
 
 #endif // ALICIA_SERVER_RACE_MAGIC_CONFIG_HPP

--- a/include/server/race/magic/MagicConfig.hpp
+++ b/include/server/race/magic/MagicConfig.hpp
@@ -44,13 +44,16 @@ public:
   const AllocationRule* GetAllocationRule(MagicType type) const;
 
   // Get group ratio for a magic group
-  const GroupRatio* GetGroupRatio(MagicGroup group) const;
+  const GroupRatio* GetGroupRatio(MagicGroup group, bool isTeamMode) const;
 
   // Get slot ratio for a magic type
   const SlotRatio* GetSlotRatio(MagicType type) const;
 
   // Get team modifier for a group and lead status
   const TeamModifier* GetTeamModifier(MagicGroup group, bool isLeading) const;
+
+  // Get slot team modifier for a magic type
+  const SlotTeamModifier* GetSlotTeamModifier(MagicType type) const;
 
   // Map magic type to group
   MagicGroup GetGroupForType(MagicType type) const;
@@ -89,8 +92,10 @@ private:
   // MagicAllocInfo (Table 216): Allocation rules per magic type
   std::array<AllocationRule, 26> allocationRules_; // Indexed by MagicType
 
-  // MagicGroupRatio (Table 214): Group probabilities by rank
-  std::array<GroupRatio, 8> groupRatios_; // Indexed by MagicGroup
+  // MagicGroupRatio (Table 214): Group probabilities by rank (Solo)
+  std::array<GroupRatio, 8> soloGroupRatios_; // Indexed by MagicGroup
+  // MagicGroupTeamRatio (Table 355): Group probabilities by rank (Team)
+  std::array<GroupRatio, 8> teamGroupRatios_; // Indexed by MagicGroup
 
   // MagicSlotRatio (Table 199): Slot probabilities by rank
   std::array<SlotRatio, 26> slotRatios_; // Indexed by MagicType
@@ -98,6 +103,9 @@ private:
   // MagicGroupTeamModifier (Table 270): Dynamic modifiers
   std::array<std::array<TeamModifier, 2>, 8> teamModifiers_;
   // [group][isLeading] -> TeamModifier
+
+  // MagicSlotTeamModifier (Table 271): Dynamic slot modifiers
+  std::array<SlotTeamModifier, 26> slotTeamModifiers_; // Indexed by MagicType
 
   // Type to group mapping
   std::array<MagicGroup, 26> typeToGroup_;      // [MagicType] -> MagicGroup
@@ -115,12 +123,22 @@ inline const AllocationRule* MagicConfig::GetAllocationRule(MagicType type) cons
   return nullptr;
 }
 
-inline const GroupRatio* MagicConfig::GetGroupRatio(MagicGroup group) const
+inline const GroupRatio* MagicConfig::GetGroupRatio(MagicGroup group, bool isTeamMode) const
 {
   uint32_t index = static_cast<uint32_t>(group);
-  if (index < groupRatios_.size())
+  if (isTeamMode)
   {
-    return &groupRatios_[index];
+    if (index < teamGroupRatios_.size())
+    {
+      return &teamGroupRatios_[index];
+    }
+  }
+  else
+  {
+    if (index < soloGroupRatios_.size())
+    {
+      return &soloGroupRatios_[index];
+    }
   }
   return nullptr;
 }
@@ -142,6 +160,16 @@ inline const TeamModifier* MagicConfig::GetTeamModifier(MagicGroup group, bool i
   if (g < teamModifiers_.size() && l < teamModifiers_[g].size())
   {
     return &teamModifiers_[g][l];
+  }
+  return nullptr;
+}
+
+inline const SlotTeamModifier* MagicConfig::GetSlotTeamModifier(MagicType type) const
+{
+  uint32_t index = ToUnderlying(type);
+  if (index < slotTeamModifiers_.size())
+  {
+    return &slotTeamModifiers_[index];
   }
   return nullptr;
 }
@@ -179,7 +207,7 @@ inline MagicGroup MagicConfig::GetPrimaryGroupForRank(uint32_t rank) const
 
   for (uint32_t g = 1; g < static_cast<uint32_t>(MagicGroup::MaxGroups); ++g)
   {
-    const auto* ratio = GetGroupRatio(static_cast<MagicGroup>(g));
+    const auto* ratio = GetGroupRatio(static_cast<MagicGroup>(g), false);
     if (ratio && ratio->rankWeights[rank - 1] > bestWeight)
     {
       bestWeight = ratio->rankWeights[rank - 1];

--- a/include/server/race/magic/MagicSelector.hpp
+++ b/include/server/race/magic/MagicSelector.hpp
@@ -1,0 +1,188 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2026 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef ALICIA_SERVER_RACE_MAGIC_SELECTOR_HPP
+#define ALICIA_SERVER_RACE_MAGIC_SELECTOR_HPP
+
+#include "server/race/magic/MagicConfig.hpp"
+#include "server/tracker/RaceTracker.hpp"
+
+#include <libserver/registry/MagicRegistry.hpp>
+
+#include <random>
+#include <vector>
+
+namespace server::magic
+{
+
+/**
+ * @brief Selects magic items for racers based on the official 4-layer hierarchical probability filter.
+ *
+ * This class implements the official magic distribution system from the game's XML configuration files:
+ * 1. MagicAllocInfo (Layer 1): Global allocation rules - filters items by rank/player count
+ * 2. MagicGroupRatio (Layer 2): Group probabilities by rank - determines which magic group to use
+ * 3. MagicSlotRatio (Layer 3): Slot probabilities by rank - determines which specific type within group
+ * 4. MagicGroupTeamModifier (Layer 4): Dynamic modifiers based on race context
+ *
+ * The system ensures:
+ * - Leaders (rank 1-2) get more defensive items (shields, ice walls)
+ * - Trailers (rank 7-8) get more offensive items (attacks, speed boosts)
+ * - Rubber-banding mechanics help trailing racers catch up
+ */
+class MagicSelector
+{
+public:
+  explicit MagicSelector(const registry::MagicRegistry& magicRegistry);
+
+  /**
+   * @brief Select a magic item for a racer based on their position.
+   *
+   * @param racer The racer requesting the item
+   * @param positionInfo The racer's current position information
+   * @param totalActiveRacers Total number of active racers in the race
+   * @return The selected magic slot info
+   */
+  registry::Magic::SlotInfo SelectItem(
+    const tracker::RaceTracker::Racer& racer,
+    const tracker::RaceTracker::RacerPositionInfo& positionInfo,
+    uint32_t totalActiveRacers) const;
+
+  /**
+   * @brief Select a magic item by character UID and race context.
+   *
+   * @param racer The racer requesting the item
+   * @param characterUid The character UID
+   * @param racePositions All racer positions sorted by track progress
+   * @return The selected magic slot info
+   */
+  registry::Magic::SlotInfo SelectItem(
+    const tracker::RaceTracker::Racer& racer,
+    data::Uid characterUid,
+    const std::vector<tracker::RaceTracker::RacerPositionInfo>& racePositions) const;
+
+private:
+  const registry::MagicRegistry& _magicRegistry;
+  mutable std::random_device _randomDevice;
+
+  /**
+   * @brief Layer 2: Select a magic group based on rank probabilities.
+   *
+   * Uses MagicGroupRatio (MagicGroupTeamRatio) to determine the most appropriate group
+   * for the current rank. This is the primary group selection layer.
+   *
+   * @param rank The racer's rank (1-8)
+   * @return The selected magic group
+   */
+  MagicGroup SelectGroupByRank(uint32_t rank) const;
+
+  /**
+   * @brief Select a group from weighted options.
+   *
+   * @param groupWeights Vector of (group, weight) pairs
+   * @return Selected magic group
+   */
+  MagicGroup SelectGroupFromWeighted(
+    const std::vector<std::pair<MagicGroup, uint32_t>>& groupWeights) const;
+
+  /**
+   * @brief Layer 3: Filter and weight types within the selected group by slot ratios.
+   *
+   * Uses MagicSlotRatio to apply rank-based weights to individual magic types.
+   * Also applies MagicGroupAttackRatio for offensive types.
+   *
+   * @param types Valid magic types from layer 1
+   * @param rank The racer's rank (1-8)
+   * @param totalRacers Total number of racers
+   * @return Vector of types with their computed weights
+   */
+  std::vector<std::pair<MagicType, uint32_t>> ApplySlotRatios(
+    const std::vector<MagicType>& types,
+    uint32_t rank,
+    uint32_t totalRacers) const;
+
+  /**
+   * @brief Layer 4: Apply dynamic modifiers based on race context.
+   *
+   * Uses MagicGroupTeamModifier to adjust weights based on:
+   * - Whether the racer is leading
+   * - How many players are ahead
+   *
+   * @param weightedTypes Types with their base weights
+   * @param context The race context
+   * @return Modified weights with dynamic adjustments
+   */
+  void ApplyDynamicModifiers(
+    std::vector<std::pair<MagicType, uint32_t>>& weightedTypes,
+    const RaceContext& context) const;
+
+  /**
+   * @brief Select a magic type from weighted options.
+   *
+   * @param weightedTypes Vector of (type, weight) pairs
+   * @return Selected magic type
+   */
+  MagicType SelectFromWeighted(const std::vector<std::pair<MagicType, uint32_t>>& weightedTypes) const;
+
+  /**
+   * @brief Build race context from position info.
+   *
+   * @param positionInfo The racer's position information
+   * @param totalActiveRacers Total number of active racers
+   * @return Race context for magic selection
+   */
+  RaceContext BuildContext(
+    const tracker::RaceTracker::RacerPositionInfo& positionInfo,
+    uint32_t totalActiveRacers) const;
+
+  /**
+   * @brief Normalize rank from [1, totalPlayers] to [1, 8] for consistent distribution.
+   *
+   * This ensures that last place in any race size gets the same treatment,
+   * and rubber-banding scales properly with player count.
+   *
+   * @param rank The racer's rank (1 = first, N = last)
+   * @param totalPlayers Total number of players in the race
+   * @return Normalized rank in range [1, 8]
+   */
+  uint32_t NormalizeRank(uint32_t rank, uint32_t totalPlayers) const;
+
+  /**
+   * @brief Get the pool of magic items for the racer's team mode.
+   *
+   * @param racer The racer
+   * @return The appropriate item pool (solo or team)
+   */
+  const std::vector<uint32_t>& GetItemPool(const tracker::RaceTracker::Racer& racer) const;
+
+  /**
+   * @brief Handle critical chance for the selected item.
+   *
+   * @param slotInfo The selected slot info
+   * @param racer The racer
+   * @param magicRegistry The magic registry
+   * @return Final slot info (possibly critical version)
+   */
+  registry::Magic::SlotInfo HandleCriticalChance(
+    registry::Magic::SlotInfo slotInfo,
+    const tracker::RaceTracker::Racer& racer) const;
+};
+
+} // namespace server::magic
+
+#endif // ALICIA_SERVER_RACE_MAGIC_SELECTOR_HPP

--- a/include/server/race/magic/MagicSelector.hpp
+++ b/include/server/race/magic/MagicSelector.hpp
@@ -28,7 +28,7 @@
 #include <random>
 #include <vector>
 
-namespace server::magic
+namespace server::race::magic
 {
 
 /**
@@ -183,6 +183,6 @@ private:
   const std::vector<uint32_t>& GetItemPool(const tracker::RaceTracker::Racer& racer) const;
 };
 
-} // namespace server::magic
+} // namespace server::race::magic
 
 #endif // ALICIA_SERVER_RACE_MAGIC_SELECTOR_HPP

--- a/include/server/race/magic/MagicSelector.hpp
+++ b/include/server/race/magic/MagicSelector.hpp
@@ -76,6 +76,17 @@ public:
     data::Uid characterUid,
     const std::vector<tracker::RaceTracker::RacerPositionInfo>& racePositions) const;
 
+  /**
+   * @brief Handle critical chance for the selected item.
+   *
+   * @param slotInfo The selected slot info
+   * @param racer The racer
+   * @return Final slot info (possibly critical version)
+   */
+  registry::Magic::SlotInfo HandleCriticalChance(
+    registry::Magic::SlotInfo slotInfo,
+    const tracker::RaceTracker::Racer& racer) const;
+
 private:
   const registry::MagicRegistry& _magicRegistry;
   mutable std::random_device _randomDevice;
@@ -87,9 +98,10 @@ private:
    * for the current rank. This is the primary group selection layer.
    *
    * @param rank The racer's rank (1-8)
+   * @param isTeamMode Whether it's team mode
    * @return The selected magic group
    */
-  MagicGroup SelectGroupByRank(uint32_t rank) const;
+  MagicGroup SelectGroupByRank(uint32_t rank, bool isTeamMode) const;
 
   /**
    * @brief Select a group from weighted options.
@@ -169,18 +181,6 @@ private:
    * @return The appropriate item pool (solo or team)
    */
   const std::vector<uint32_t>& GetItemPool(const tracker::RaceTracker::Racer& racer) const;
-
-  /**
-   * @brief Handle critical chance for the selected item.
-   *
-   * @param slotInfo The selected slot info
-   * @param racer The racer
-   * @param magicRegistry The magic registry
-   * @return Final slot info (possibly critical version)
-   */
-  registry::Magic::SlotInfo HandleCriticalChance(
-    registry::Magic::SlotInfo slotInfo,
-    const tracker::RaceTracker::Racer& racer) const;
 };
 
 } // namespace server::magic

--- a/include/server/race/magic/MagicTypes.hpp
+++ b/include/server/race/magic/MagicTypes.hpp
@@ -173,6 +173,19 @@ struct TeamModifier
   bool appliesWhenLeading = false; // true if this applies when leading
 };
 
+// ============================================================================
+// SLOT TEAM MODIFIERS (from MagicSlotTeamModifier.xml, Table 271)
+// ============================================================================
+
+struct SlotTeamModifier
+{
+  int32_t ahead1 = 0;              // Modifier when 1 player ahead
+  int32_t ahead2 = 0;              // Modifier when 2 players ahead
+  int32_t ahead3 = 0;              // Modifier when 3 players ahead
+  int32_t ahead4 = 0;              // Modifier when 4 players ahead
+  bool appliesWhenLeading = false; // true if this applies when leading
+};
+
 } // namespace server::magic
 
 #endif // ALICIA_SERVER_RACE_MAGIC_TYPES_HPP

--- a/include/server/race/magic/MagicTypes.hpp
+++ b/include/server/race/magic/MagicTypes.hpp
@@ -25,13 +25,10 @@
 #include <unordered_map>
 #include <vector>
 
-namespace server::magic
+namespace server::race::magic
 {
 
-// ============================================================================
-// MAGIC TYPES
-// ============================================================================
-
+//! Magic Types
 enum class MagicType : uint8_t
 {
   Invalid = 0,
@@ -68,10 +65,7 @@ inline uint32_t ToUnderlying(MagicType type)
   return static_cast<uint32_t>(type);
 }
 
-// ============================================================================
-// MAGIC GROUPS
-// ============================================================================
-
+//! Magic Groups
 enum class MagicGroup : uint8_t
 {
   Invalid = 0,
@@ -85,10 +79,7 @@ enum class MagicGroup : uint8_t
   MaxGroups = 8
 };
 
-// ============================================================================
-// BASIC TYPES
-// ============================================================================
-
+//! Basic Types
 enum class BasicType : uint8_t
 {
   Invalid = 0,
@@ -107,10 +98,7 @@ enum class BasicType : uint8_t
   MaxBasicTypes = 25
 };
 
-// ============================================================================
-// RACE CONTEXT
-// ============================================================================
-
+//! Race Context
 struct RaceContext
 {
   uint32_t rank = 0;           // 1-N (1 = first, N = last, where N = totalPlayers)
@@ -122,10 +110,7 @@ struct RaceContext
   MagicGroup group = MagicGroup::Invalid;
 };
 
-// ============================================================================
-// ALLOCATION RULES (from MagicAllocInfo.xml, Table 216)
-// ============================================================================
-
+//! Allocations Rules (from MagicAllocInfo, Table 216)
 struct AllocationRule
 {
   uint32_t minRank = 1;
@@ -139,31 +124,24 @@ struct AllocationRule
   float conditionValue = 0.0f;
 };
 
-// ============================================================================
-// SLOT RATIOS (from MagicSlotRatio.xml, Table 199)
-// ============================================================================
+//! Slot Ratios (from MagicSlotRatio, Table 199)
 
-// Slot ratio for each magic type by rank (1-8)
-// Values represent percentage probability * 100 (e.g., 70 = 70%)
+//! Slot ratio for each magic type by rank (1-8)
+//! Values represent percentage probability * 100 (e.g., 70 = 70%)
 struct SlotRatio
 {
   std::array<uint32_t, 8> rankWeights; // [0] = rank 1, [7] = rank 8
 };
 
-// ============================================================================
-// GROUP RATIOS (from MagicGroupRatio.xml, Table 214)
-// ============================================================================
+//! Group Ratios (from MagicGroupRatio, Table 214)
 
-// Group probability by rank
+//! Group probability by rank
 struct GroupRatio
 {
   std::array<uint32_t, 8> rankWeights; // Weight for each rank 1-8
 };
 
-// ============================================================================
-// TEAM MODIFIERS (from MagicGroupTeamModifier.xml, Table 270)
-// ============================================================================
-
+//! Team Modifiers (from MagicGroupTeamModifier, Table 270)
 struct TeamModifier
 {
   int32_t ahead1 = 0;              // Modifier when 1 player ahead
@@ -173,10 +151,7 @@ struct TeamModifier
   bool appliesWhenLeading = false; // true if this applies when leading
 };
 
-// ============================================================================
-// SLOT TEAM MODIFIERS (from MagicSlotTeamModifier.xml, Table 271)
-// ============================================================================
-
+//! Slot Team Modifiers (from MagicSlotTeamModifier, Table 271)
 struct SlotTeamModifier
 {
   int32_t ahead1 = 0;              // Modifier when 1 player ahead
@@ -186,6 +161,6 @@ struct SlotTeamModifier
   bool appliesWhenLeading = false; // true if this applies when leading
 };
 
-} // namespace server::magic
+} // namespace server::race::magic
 
 #endif // ALICIA_SERVER_RACE_MAGIC_TYPES_HPP

--- a/include/server/race/magic/MagicTypes.hpp
+++ b/include/server/race/magic/MagicTypes.hpp
@@ -1,0 +1,178 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2026 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef ALICIA_SERVER_RACE_MAGIC_TYPES_HPP
+#define ALICIA_SERVER_RACE_MAGIC_TYPES_HPP
+
+#include <array>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace server::magic
+{
+
+// ============================================================================
+// MAGIC TYPES
+// ============================================================================
+
+enum class MagicType : uint8_t
+{
+  Invalid = 0,
+  FireBall = 2,
+  FireBallCritical = 3,
+  WaterShield = 4,
+  WaterShieldCritical = 5,
+  Booster = 6,
+  BoosterCritical = 7,
+  HotRodding = 8,
+  HotRoddingCritical = 9,
+  IceWall = 10,
+  IceWallCritical = 11,
+  JumpStun = 12,
+  JumpStunCritical = 13,
+  DarkFire = 14,
+  DarkFireCritical = 15,
+  Summon = 16,
+  SummonCritical = 17,
+  Lightning = 18,
+  LightningCritical = 19,
+  BufPower = 20,
+  BufPowerCritical = 21,
+  BufGauge = 22,
+  BufGaugeCritical = 23,
+  BufSpeed = 24,
+  BufSpeedCritical = 25,
+  MaxTypes = 26
+};
+
+// Convert MagicType to underlying type for storage
+inline uint32_t ToUnderlying(MagicType type)
+{
+  return static_cast<uint32_t>(type);
+}
+
+// ============================================================================
+// MAGIC GROUPS
+// ============================================================================
+
+enum class MagicGroup : uint8_t
+{
+  Invalid = 0,
+  Offensive = 1,    // FireBall, DarkFire, Summon, Lightning, JumpStun
+  Defensive = 2,    // WaterShield
+  SpeedUtility = 3, // Booster, HotRodding
+  Special = 4,
+  RareOffensive = 5, // JumpStun (from MagicGroupTeamRatio)
+  RareSpeed = 6,
+  RareUtility = 7,
+  MaxGroups = 8
+};
+
+// ============================================================================
+// BASIC TYPES
+// ============================================================================
+
+enum class BasicType : uint8_t
+{
+  Invalid = 0,
+  FireBall = 2,
+  WaterShield = 4,
+  Booster = 6,
+  HotRodding = 8,
+  IceWall = 10,
+  JumpStun = 12,
+  DarkFire = 14,
+  Summon = 16,
+  Lightning = 18,
+  BufPower = 20,
+  BufGauge = 22,
+  BufSpeed = 24,
+  MaxBasicTypes = 25
+};
+
+// ============================================================================
+// RACE CONTEXT
+// ============================================================================
+
+struct RaceContext
+{
+  uint32_t rank = 0;           // 1-N (1 = first, N = last, where N = totalPlayers)
+  uint32_t normalizedRank = 0; // 1-8 (normalized to 8-player scale for consistent distribution)
+  uint32_t totalPlayers = 0;   // 1-8
+  uint32_t aheadCount = 0;     // Number of players ahead (0-7)
+  bool isLeading = false;      // true if this racer is in 1st place
+  bool isTeamMode = false;     // true for team races
+  MagicGroup group = MagicGroup::Invalid;
+};
+
+// ============================================================================
+// ALLOCATION RULES (from MagicAllocInfo.xml, Table 216)
+// ============================================================================
+
+struct AllocationRule
+{
+  uint32_t minRank = 1;
+  uint32_t maxRank = 8;
+  uint32_t minPlayerCount = 1;
+  float minRatio = 0.0f;
+  float maxRatio = 1.0f;
+  uint32_t weight = 1;
+  uint32_t maxCount = 1;
+  uint32_t conditionType = 0;
+  float conditionValue = 0.0f;
+};
+
+// ============================================================================
+// SLOT RATIOS (from MagicSlotRatio.xml, Table 199)
+// ============================================================================
+
+// Slot ratio for each magic type by rank (1-8)
+// Values represent percentage probability * 100 (e.g., 70 = 70%)
+struct SlotRatio
+{
+  std::array<uint32_t, 8> rankWeights; // [0] = rank 1, [7] = rank 8
+};
+
+// ============================================================================
+// GROUP RATIOS (from MagicGroupRatio.xml, Table 214)
+// ============================================================================
+
+// Group probability by rank
+struct GroupRatio
+{
+  std::array<uint32_t, 8> rankWeights; // Weight for each rank 1-8
+};
+
+// ============================================================================
+// TEAM MODIFIERS (from MagicGroupTeamModifier.xml, Table 270)
+// ============================================================================
+
+struct TeamModifier
+{
+  int32_t ahead1 = 0;              // Modifier when 1 player ahead
+  int32_t ahead2 = 0;              // Modifier when 2 players ahead
+  int32_t ahead3 = 0;              // Modifier when 3 players ahead
+  int32_t ahead4 = 0;              // Modifier when 4 players ahead
+  bool appliesWhenLeading = false; // true if this applies when leading
+};
+
+} // namespace server::magic
+
+#endif // ALICIA_SERVER_RACE_MAGIC_TYPES_HPP

--- a/include/server/tracker/RaceTracker.hpp
+++ b/include/server/tracker/RaceTracker.hpp
@@ -113,6 +113,9 @@ public:
     };
     MountStatsSnapshot mountStats{};
 
+    // Track progress from client updates (AcCmdUserRaceUpdatePos::member6)
+    float trackProgress = 0.0f;
+
     struct MagicTargetInfo
     {
       uint16_t casterOid;
@@ -224,6 +227,21 @@ public:
   uint16_t GetNextEffectInstanceIdAndIncrementBy(uint16_t increment);
 
   void Clear();
+
+  // Position tracking for magic item distribution
+  struct RacerPositionInfo
+  {
+    data::Uid characterUid{};
+    float trackProgress = 0.0f;
+    uint32_t rank = 0;
+    Oid oid{};
+  };
+
+  // Get all racers sorted by track progress (best to worst)
+  std::vector<RacerPositionInfo> GetRacePositions() const;
+
+  // Get position info for a specific racer
+  std::optional<RacerPositionInfo> GetRacerPosition(data::Uid characterUid) const;
 
 private:
   //! Mapping between character UIDs and their assigned OIDs.

--- a/src/server/race/RaceNetworkHandler.cpp
+++ b/src/server/race/RaceNetworkHandler.cpp
@@ -61,7 +61,7 @@ registry::Magic::SlotInfo RandomMagicItem(
   const std::vector<tracker::RaceTracker::RacerPositionInfo>& racePositions)
 {
   // Use the new MagicSelector with official 4-layer hierarchical filter
-  magic::MagicSelector selector(serverInstance.GetMagicRegistry());
+  race::magic::MagicSelector selector(serverInstance.GetMagicRegistry());
   auto slotInfo = selector.SelectItem(racer, characterUid, racePositions);
 
   return slotInfo;
@@ -2767,7 +2767,7 @@ void RaceNetworkHandler::HandleUserRaceItemGet(
           .GetDeckItemInfo(magicItemType).magicSlot;
 
         // Apply critical upgrade chance
-        magic::MagicSelector selector(_serverInstance.GetMagicRegistry());
+        race::magic::MagicSelector selector(_serverInstance.GetMagicRegistry());
         auto slotInfo = selector.HandleCriticalChance(
           _serverInstance.GetMagicRegistry().GetSlotInfo(magicItem), racer);
         magicItem = slotInfo.type;

--- a/src/server/race/RaceNetworkHandler.cpp
+++ b/src/server/race/RaceNetworkHandler.cpp
@@ -2766,6 +2766,12 @@ void RaceNetworkHandler::HandleUserRaceItemGet(
         magicItem = _serverInstance.GetCourseRegistry()
           .GetDeckItemInfo(magicItemType).magicSlot;
 
+        // Apply critical upgrade chance
+        magic::MagicSelector selector(_serverInstance.GetMagicRegistry());
+        auto slotInfo = selector.HandleCriticalChance(
+          _serverInstance.GetMagicRegistry().GetSlotInfo(magicItem), racer);
+        magicItem = slotInfo.type;
+
         // Response with OK to the client that they have a new item in hand
         protocol::AcCmdCRRequestMagicItemOK magicItemOk{
           .characterOid = command.characterOid,

--- a/src/server/race/RaceNetworkHandler.cpp
+++ b/src/server/race/RaceNetworkHandler.cpp
@@ -20,6 +20,7 @@
 #include "server/race/RaceNetworkHandler.hpp"
 
 #include "server/ServerInstance.hpp"
+#include "server/race/magic/MagicSelector.hpp"
 
 #include <libserver/data/helper/ProtocolHelper.hpp>
 
@@ -55,45 +56,15 @@ uint32_t GetMountStatValue(
 
 registry::Magic::SlotInfo RandomMagicItem(
   ServerInstance& serverInstance,
-  const tracker::RaceTracker::Racer& racer)
+  const tracker::RaceTracker::Racer& racer,
+  data::Uid characterUid,
+  const std::vector<tracker::RaceTracker::RacerPositionInfo>& racePositions)
 {
-  const auto& itemPool = (racer.team == tracker::RaceTracker::Racer::Team::Solo
-    ? serverInstance.GetMagicRegistry().GetSoloPool()
-    : serverInstance.GetMagicRegistry().GetTeamPool());
+  // Use the new MagicSelector with official 4-layer hierarchical filter
+  magic::MagicSelector selector(serverInstance.GetMagicRegistry());
+  auto slotInfo = selector.SelectItem(racer, characterUid, racePositions);
 
-  // Build weights: Lightning (type 18) gets a reduced roll chance.
-  // Booster, HotRodding, and team-only items get a slightly reduced chance as well.
-  // TODO: Replace with a proper per-spell weight system.
-  const auto& magicRegistry = serverInstance.GetMagicRegistry();
-  std::vector<uint32_t> weights;
-  weights.reserve(itemPool.size());
-  for (const uint32_t type : itemPool)
-  {
-    const auto& slotInfo = magicRegistry.GetSlotInfo(type);
-    const uint32_t w = (type == 18) ? 1u
-      : (slotInfo.basicType == 6 || slotInfo.basicType == 8 || slotInfo.basicType == 12) ? 2u
-      : (slotInfo.teamMode != 0) ? 2u
-      : 4u;
-    weights.push_back(w);
-  }
-
-  std::discrete_distribution<size_t> distribution(weights.begin(), weights.end());
-  auto magicSlotInfo = magicRegistry.GetSlotInfo(itemPool[distribution(_randomDevice)]);
-  uint32_t critChanceBp = magicRegistry.GetBaseCritChanceBp();
-  if (magicSlotInfo.criticalType != 0)
-  {
-    if (const auto* scaling = magicRegistry.GetStatScaling(magicSlotInfo.basicType))
-    {
-      const uint32_t statValue = GetMountStatValue(racer.mountStats, scaling->stat);
-      critChanceBp += scaling->critStepBp * (statValue / 10u);
-    }
-  }
-
-  if ((rand() % 10000) < static_cast<int>(critChanceBp))
-  {
-    magicSlotInfo = serverInstance.GetMagicRegistry().GetSlotInfo(magicSlotInfo.criticalType);
-  }
-  return magicSlotInfo;
+  return slotInfo;
 }
 
 } // anon namespace
@@ -1325,17 +1296,17 @@ void RaceNetworkHandler::HandleStartRace(
     return;
   }
 
-  constexpr uint32_t GameCountdownKey = 17;
-  constexpr uint32_t DefaultCountdownMs = 5310;
-
-  const auto& countdown = GetServerInstance()
-    .GetSystemContentRegistry()
-    .GetValue(GameCountdownKey);
+  uint32_t roomCountdownMs = 0;
+  if (parameters.gameMode != protocol::GameMode::Tutorial)
+  {
+    constexpr uint32_t GameCountdownKey = 17;
+    constexpr uint32_t DefaultCountdownMs = 5310;
+    const auto& countdown = GetServerInstance().GetSystemContentRegistry().GetValue(GameCountdownKey);
+    roomCountdownMs = countdown.has_value() ? countdown.value() : DefaultCountdownMs;
+  }
 
   const protocol::AcCmdRCRoomCountdown roomCountdown{
-    .countdown = countdown.has_value()
-      ? countdown.value()
-      : DefaultCountdownMs,
+    .countdown = roomCountdownMs,
     .mapBlockId = static_cast<uint16_t>(raceInstance.GetMapBlockId())};
 
   // Broadcast room countdown.
@@ -2138,6 +2109,9 @@ void RaceNetworkHandler::HandleRaceUserPos(
   // TODO: player position anticheat
 
   racer.position = command.position;
+
+  // Store track progress from member6 for position-based magic distribution
+  racer.trackProgress = command.member6;
 }
 
 void RaceNetworkHandler::HandleChat(
@@ -2459,7 +2433,11 @@ void RaceNetworkHandler::HandleRequestMagicItem(
     return;
   }
 
-  racer.magicItem.emplace(RandomMagicItem(_serverInstance, racer).type);
+  // Get current race positions for position-based distribution
+  auto racePositions = raceInstance.GetTracker().GetRacePositions();
+
+  // Select magic item based on racer's position
+  racer.magicItem.emplace(RandomMagicItem(_serverInstance, racer, clientContext.characterUid, racePositions).type);
   racer.starPointValue = 0;
 
   protocol::AcCmdCRStarPointGetOK starPointResponse{

--- a/src/server/race/magic/MagicConfig.cpp
+++ b/src/server/race/magic/MagicConfig.cpp
@@ -1,0 +1,272 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2026 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#include "server/race/magic/MagicConfig.hpp"
+
+namespace server::magic
+{
+
+MagicConfig::MagicConfig()
+{
+  InitializeAllocationRules();
+  InitializeGroupRatios();
+  InitializeSlotRatios();
+  InitializeTeamModifiers();
+  InitializeTypeMappings();
+}
+
+void MagicConfig::InitializeAllocationRules()
+{
+  // Initialize all rules with default values (allow all ranks and player counts)
+  // Then override specific types with data from MagicAllocInfo.xml
+  for (auto& rule : allocationRules_)
+  {
+    rule = {
+      .minRank = 1,
+      .maxRank = 8,
+      .minPlayerCount = 1,
+      .minRatio = 0.0f,
+      .maxRatio = 1.0f,
+      .weight = 1,
+      .maxCount = 1,
+      .conditionType = 0,
+      .conditionValue = 0.0f};
+  }
+
+  // Data from MagicAllocInfo.xml (Table 216)
+  // Only types with specific rules are overridden
+  allocationRules_[ToUnderlying(MagicType::WaterShieldCritical)] = {
+    .minRank = 3,
+    .maxRank = 6,
+    .minPlayerCount = 3,
+    .minRatio = 0.25f,
+    .maxRatio = 0.80f,
+    .weight = 80,
+    .maxCount = 1,
+    .conditionType = 1,
+    .conditionValue = 200.0f};
+
+  allocationRules_[ToUnderlying(MagicType::Booster)] = {
+    .minRank = 7,
+    .maxRank = 8,
+    .minPlayerCount = 3,
+    .minRatio = 0.20f,
+    .maxRatio = 0.80f,
+    .weight = 50,
+    .maxCount = 2,
+    .conditionType = 2,
+    .conditionValue = 300.0f};
+}
+
+void MagicConfig::InitializeGroupRatios()
+{
+  for (auto& ratio : groupRatios_)
+  {
+    ratio = GroupRatio{};
+  }
+
+  // Data from MagicGroupTeamRatio.xml (Table 355)
+  // Exact values from the XML table
+  groupRatios_[static_cast<uint32_t>(MagicGroup::Offensive)].rankWeights = {0, 45, 50, 65, 65, 60, 44, 11};
+  groupRatios_[static_cast<uint32_t>(MagicGroup::Defensive)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
+  groupRatios_[static_cast<uint32_t>(MagicGroup::SpeedUtility)].rankWeights = {5, 40, 30, 25, 40, 35, 44, 82};
+  groupRatios_[static_cast<uint32_t>(MagicGroup::Special)].rankWeights = {35, 0, 0, 0, 0, 0, 0, 0};
+  groupRatios_[static_cast<uint32_t>(MagicGroup::RareOffensive)].rankWeights = {0, 0, 5, 3, 3, 3, 0, 0};
+  groupRatios_[static_cast<uint32_t>(MagicGroup::RareSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 4, 11};
+  groupRatios_[static_cast<uint32_t>(MagicGroup::RareUtility)].rankWeights = {0, 0, 0, 0, 0, 0, 22, 22};
+}
+
+void MagicConfig::InitializeSlotRatios()
+{
+  // Initialize all to a low default
+  SlotRatio defaultRatio;
+  defaultRatio.rankWeights = {5, 5, 5, 5, 5, 5, 5, 5};
+
+  for (auto& ratio : slotRatios_)
+  {
+    ratio = defaultRatio;
+  }
+
+  // DEFENSIVE ITEMS (Group 2)
+  slotRatios_[ToUnderlying(MagicType::WaterShield)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::WaterShieldCritical)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::IceWall)].rankWeights = {50, 15, 0, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::IceWallCritical)].rankWeights = {50, 15, 0, 0, 0, 0, 0, 0};
+
+  // SPEED/UTILITY ITEMS (Group 3)
+  // Based on original game: Booster & HotRodding had half weight (2 vs 4)
+  // So their slot ratios are ~50% of other items
+  // Matching MagicGroupAttackRatio scale for other items
+  slotRatios_[ToUnderlying(MagicType::Booster)].rankWeights = {0, 10, 17, 15, 17, 17, 22, 32};
+  slotRatios_[ToUnderlying(MagicType::BoosterCritical)].rankWeights = {0, 10, 17, 15, 17, 17, 22, 32};
+  slotRatios_[ToUnderlying(MagicType::HotRodding)].rankWeights = {0, 7, 15, 12, 15, 15, 20, 27};
+  slotRatios_[ToUnderlying(MagicType::HotRoddingCritical)].rankWeights = {0, 7, 15, 12, 15, 15, 20, 27};
+  slotRatios_[ToUnderlying(MagicType::BufGauge)].rankWeights = {0, 0, 0, 0, 0, 0, 5, 5};
+  slotRatios_[ToUnderlying(MagicType::BufGaugeCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 5, 5};
+  slotRatios_[ToUnderlying(MagicType::BufSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
+  slotRatios_[ToUnderlying(MagicType::BufSpeedCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
+
+  // OFFENSIVE ITEMS (Group 1)
+  // Directly from MagicGroupAttackRatio (Table 217):
+  // Type 2 (FireBall):  0-15-15-10-10-25-5-10
+  // Type 14 (DarkFire): 0-20-17-10-10-15-10-10
+  // Type 16 (Summon):   0-5-15-15-15-10-10-5
+  // Type 12 (JumpStun): 0-0-0-0-5-25-0-0
+  // Type 18 (Lightning): NOT in table -> use legacy reduced weight
+
+  // FireBall - directly from MagicGroupAttackRatio
+  slotRatios_[ToUnderlying(MagicType::FireBall)].rankWeights = {0, 15, 15, 10, 10, 25, 5, 10};
+  slotRatios_[ToUnderlying(MagicType::FireBallCritical)].rankWeights = {0, 15, 15, 10, 10, 25, 5, 10};
+
+  // DarkFire - directly from MagicGroupAttackRatio
+  slotRatios_[ToUnderlying(MagicType::DarkFire)].rankWeights = {0, 20, 17, 10, 10, 15, 10, 10};
+  slotRatios_[ToUnderlying(MagicType::DarkFireCritical)].rankWeights = {0, 20, 17, 10, 10, 15, 10, 10};
+
+  // Summon - directly from MagicGroupAttackRatio
+  slotRatios_[ToUnderlying(MagicType::Summon)].rankWeights = {0, 5, 15, 15, 15, 10, 10, 5};
+  slotRatios_[ToUnderlying(MagicType::SummonCritical)].rankWeights = {0, 5, 15, 15, 15, 10, 10, 5};
+
+  // JumpStun - directly from MagicGroupAttackRatio
+  slotRatios_[ToUnderlying(MagicType::JumpStun)].rankWeights = {0, 0, 0, 0, 5, 25, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::JumpStunCritical)].rankWeights = {0, 0, 0, 0, 5, 25, 0, 0};
+
+  // Lightning - NOT in MagicGroupAttackRatio
+  // Legacy code gives it weight=1 (vs 4 for others), so ~25% of normal offensive items
+  // Since it's not in the attack ratio table, use 25% of FireBall/DarkFire ratios
+  // FireBall: {0, 15, 15, 10, 10, 25, 5, 10}
+  // DarkFire: {0, 20, 17, 10, 10, 15, 10, 10}
+  // Lightning (25% of average): {0, 3, 4, 2, 2, 6, 2, 3}
+  slotRatios_[ToUnderlying(MagicType::Lightning)].rankWeights = {0, 3, 4, 2, 2, 6, 2, 3};
+  slotRatios_[ToUnderlying(MagicType::LightningCritical)].rankWeights = {0, 3, 4, 2, 2, 6, 2, 3};
+
+  // TEAM ASSISTANCE ITEMS
+  slotRatios_[ToUnderlying(MagicType::BufPower)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
+  slotRatios_[ToUnderlying(MagicType::BufPowerCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
+}
+
+void MagicConfig::InitializeTeamModifiers()
+{
+  for (auto& groupMods : teamModifiers_)
+  {
+    for (auto& mod : groupMods)
+    {
+      mod = TeamModifier{};
+    }
+  }
+
+  teamModifiers_[static_cast<uint32_t>(MagicGroup::Offensive)][0] = {
+    .ahead1 = 10, .ahead2 = 10, .ahead3 = 10, .ahead4 = 10, .appliesWhenLeading = false};
+  teamModifiers_[static_cast<uint32_t>(MagicGroup::Offensive)][1] = {
+    .ahead1 = -10, .ahead2 = -10, .ahead3 = -10, .ahead4 = -10, .appliesWhenLeading = true};
+  teamModifiers_[static_cast<uint32_t>(MagicGroup::Defensive)][1] = {
+    .ahead1 = 10, .ahead2 = 5, .ahead3 = 0, .ahead4 = 0, .appliesWhenLeading = true};
+  teamModifiers_[static_cast<uint32_t>(MagicGroup::SpeedUtility)][1] = {
+    .ahead1 = 10, .ahead2 = 5, .ahead3 = 0, .ahead4 = 0, .appliesWhenLeading = true};
+  teamModifiers_[static_cast<uint32_t>(MagicGroup::RareOffensive)][1] = {
+    .ahead1 = -100, .ahead2 = -100, .ahead3 = -100, .ahead4 = -100, .appliesWhenLeading = true};
+  teamModifiers_[static_cast<uint32_t>(MagicGroup::RareUtility)][1] = {
+    .ahead1 = -10, .ahead2 = -10, .ahead3 = -20, .ahead4 = -20, .appliesWhenLeading = true};
+}
+
+void MagicConfig::InitializeTypeMappings()
+{
+  typeToGroup_.fill(MagicGroup::Invalid);
+  basicTypeToGroup_.fill(MagicGroup::Invalid);
+
+  for (uint32_t t = static_cast<uint32_t>(MagicType::FireBall);
+    t < static_cast<uint32_t>(MagicType::MaxTypes);
+    ++t)
+  {
+    allMagicTypes_.push_back(static_cast<MagicType>(t));
+  }
+
+  // Offensive Group (1)
+  typeToGroup_[ToUnderlying(MagicType::FireBall)] = MagicGroup::Offensive;
+  typeToGroup_[ToUnderlying(MagicType::FireBallCritical)] = MagicGroup::Offensive;
+  typeToGroup_[ToUnderlying(MagicType::DarkFire)] = MagicGroup::Offensive;
+  typeToGroup_[ToUnderlying(MagicType::DarkFireCritical)] = MagicGroup::Offensive;
+  typeToGroup_[ToUnderlying(MagicType::Summon)] = MagicGroup::Offensive;
+  typeToGroup_[ToUnderlying(MagicType::SummonCritical)] = MagicGroup::Offensive;
+  typeToGroup_[ToUnderlying(MagicType::Lightning)] = MagicGroup::Offensive;
+  typeToGroup_[ToUnderlying(MagicType::LightningCritical)] = MagicGroup::Offensive;
+
+  // Defensive Group (2)
+  typeToGroup_[ToUnderlying(MagicType::WaterShield)] = MagicGroup::Defensive;
+  typeToGroup_[ToUnderlying(MagicType::WaterShieldCritical)] = MagicGroup::Defensive;
+  typeToGroup_[ToUnderlying(MagicType::IceWall)] = MagicGroup::Defensive;
+  typeToGroup_[ToUnderlying(MagicType::IceWallCritical)] = MagicGroup::Defensive;
+
+  // SpeedUtility Group (3)
+  typeToGroup_[ToUnderlying(MagicType::Booster)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::BoosterCritical)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::HotRodding)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::HotRoddingCritical)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::BufGauge)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::BufGaugeCritical)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::BufSpeed)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::BufSpeedCritical)] = MagicGroup::SpeedUtility;
+
+  // RareOffensive Group (5)
+  typeToGroup_[ToUnderlying(MagicType::JumpStun)] = MagicGroup::RareOffensive;
+  typeToGroup_[ToUnderlying(MagicType::JumpStunCritical)] = MagicGroup::RareOffensive;
+
+  // Team buff items
+  typeToGroup_[ToUnderlying(MagicType::BufPower)] = MagicGroup::SpeedUtility;
+  typeToGroup_[ToUnderlying(MagicType::BufPowerCritical)] = MagicGroup::SpeedUtility;
+
+  // BasicType to Group
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::FireBall)] = MagicGroup::Offensive;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::WaterShield)] = MagicGroup::Defensive;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::Booster)] = MagicGroup::SpeedUtility;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::HotRodding)] = MagicGroup::SpeedUtility;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::IceWall)] = MagicGroup::Defensive;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::JumpStun)] = MagicGroup::RareOffensive;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::DarkFire)] = MagicGroup::Offensive;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::Summon)] = MagicGroup::Offensive;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::Lightning)] = MagicGroup::Offensive;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::BufPower)] = MagicGroup::SpeedUtility;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::BufGauge)] = MagicGroup::SpeedUtility;
+  basicTypeToGroup_[static_cast<uint32_t>(BasicType::BufSpeed)] = MagicGroup::SpeedUtility;
+}
+
+std::vector<MagicType> MagicConfig::GetValidTypesForContext(const RaceContext& context) const
+{
+  std::vector<MagicType> validTypes;
+
+  for (MagicType type : allMagicTypes_)
+  {
+    if (type == MagicType::Invalid)
+      continue;
+
+    const AllocationRule* rule = GetAllocationRule(type);
+
+    if (rule && (context.totalPlayers < rule->minPlayerCount ||
+                  context.rank < rule->minRank ||
+                  context.rank > rule->maxRank))
+    {
+      continue;
+    }
+
+    validTypes.push_back(type);
+  }
+
+  return validTypes;
+}
+
+} // namespace server::magic

--- a/src/server/race/magic/MagicConfig.cpp
+++ b/src/server/race/magic/MagicConfig.cpp
@@ -76,20 +76,32 @@ void MagicConfig::InitializeAllocationRules()
 
 void MagicConfig::InitializeGroupRatios()
 {
-  for (auto& ratio : groupRatios_)
+  for (auto& ratio : soloGroupRatios_)
+  {
+    ratio = GroupRatio{};
+  }
+  for (auto& ratio : teamGroupRatios_)
   {
     ratio = GroupRatio{};
   }
 
-  // Data from MagicGroupTeamRatio.xml (Table 355)
-  // Exact values from the XML table
-  groupRatios_[static_cast<uint32_t>(MagicGroup::Offensive)].rankWeights = {0, 45, 50, 65, 65, 60, 44, 11};
-  groupRatios_[static_cast<uint32_t>(MagicGroup::Defensive)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
-  groupRatios_[static_cast<uint32_t>(MagicGroup::SpeedUtility)].rankWeights = {5, 40, 30, 25, 40, 35, 44, 82};
-  groupRatios_[static_cast<uint32_t>(MagicGroup::Special)].rankWeights = {35, 0, 0, 0, 0, 0, 0, 0};
-  groupRatios_[static_cast<uint32_t>(MagicGroup::RareOffensive)].rankWeights = {0, 0, 5, 3, 3, 3, 0, 0};
-  groupRatios_[static_cast<uint32_t>(MagicGroup::RareSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 4, 11};
-  groupRatios_[static_cast<uint32_t>(MagicGroup::RareUtility)].rankWeights = {0, 0, 0, 0, 0, 0, 22, 22};
+  // Data from MagicGroupRatio.xml (Table 214) - Solo mode
+  soloGroupRatios_[static_cast<uint32_t>(MagicGroup::Offensive)].rankWeights = {0, 45, 60, 65, 65, 60, 44, 11};
+  soloGroupRatios_[static_cast<uint32_t>(MagicGroup::Defensive)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
+  soloGroupRatios_[static_cast<uint32_t>(MagicGroup::SpeedUtility)].rankWeights = {5, 40, 30, 25, 40, 35, 44, 82};
+  soloGroupRatios_[static_cast<uint32_t>(MagicGroup::Special)].rankWeights = {35, 0, 0, 0, 0, 0, 0, 0};
+  soloGroupRatios_[static_cast<uint32_t>(MagicGroup::RareOffensive)].rankWeights = {0, 0, 5, 3, 3, 3, 0, 0};
+  soloGroupRatios_[static_cast<uint32_t>(MagicGroup::RareSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 4, 11};
+  soloGroupRatios_[static_cast<uint32_t>(MagicGroup::RareUtility)].rankWeights = {0, 0, 0, 0, 0, 0, 22, 22};
+
+  // Data from MagicGroupTeamRatio.xml (Table 355) - Team mode
+  teamGroupRatios_[static_cast<uint32_t>(MagicGroup::Offensive)].rankWeights = {0, 45, 50, 65, 65, 60, 44, 11};
+  teamGroupRatios_[static_cast<uint32_t>(MagicGroup::Defensive)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
+  teamGroupRatios_[static_cast<uint32_t>(MagicGroup::SpeedUtility)].rankWeights = {5, 40, 30, 25, 40, 35, 44, 82};
+  teamGroupRatios_[static_cast<uint32_t>(MagicGroup::Special)].rankWeights = {35, 0, 0, 0, 0, 0, 0, 0};
+  teamGroupRatios_[static_cast<uint32_t>(MagicGroup::RareOffensive)].rankWeights = {0, 0, 5, 3, 3, 3, 0, 0};
+  teamGroupRatios_[static_cast<uint32_t>(MagicGroup::RareSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 4, 11};
+  teamGroupRatios_[static_cast<uint32_t>(MagicGroup::RareUtility)].rankWeights = {0, 0, 0, 0, 0, 0, 22, 22};
 }
 
 void MagicConfig::InitializeSlotRatios()
@@ -103,61 +115,42 @@ void MagicConfig::InitializeSlotRatios()
     ratio = defaultRatio;
   }
 
-  // DEFENSIVE ITEMS (Group 2)
-  slotRatios_[ToUnderlying(MagicType::WaterShield)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
-  slotRatios_[ToUnderlying(MagicType::WaterShieldCritical)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
-  slotRatios_[ToUnderlying(MagicType::IceWall)].rankWeights = {50, 15, 0, 0, 0, 0, 0, 0};
-  slotRatios_[ToUnderlying(MagicType::IceWallCritical)].rankWeights = {50, 15, 0, 0, 0, 0, 0, 0};
+  // DEFENSIVE ITEMS (Group 2) - MagicSlotRatio (Table 199)
+  slotRatios_[ToUnderlying(MagicType::WaterShield)].rankWeights = {15, 5, 5, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::WaterShieldCritical)].rankWeights = {15, 5, 5, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::IceWall)].rankWeights = {25, 0, 0, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::IceWallCritical)].rankWeights = {25, 0, 0, 0, 0, 0, 0, 0};
 
-  // SPEED/UTILITY ITEMS (Group 3)
-  // Based on original game: Booster & HotRodding had half weight (2 vs 4)
-  // So their slot ratios are ~50% of other items
-  // Matching MagicGroupAttackRatio scale for other items
-  slotRatios_[ToUnderlying(MagicType::Booster)].rankWeights = {0, 10, 17, 15, 17, 17, 22, 32};
-  slotRatios_[ToUnderlying(MagicType::BoosterCritical)].rankWeights = {0, 10, 17, 15, 17, 17, 22, 32};
-  slotRatios_[ToUnderlying(MagicType::HotRodding)].rankWeights = {0, 7, 15, 12, 15, 15, 20, 27};
-  slotRatios_[ToUnderlying(MagicType::HotRoddingCritical)].rankWeights = {0, 7, 15, 12, 15, 15, 20, 27};
-  slotRatios_[ToUnderlying(MagicType::BufGauge)].rankWeights = {0, 0, 0, 0, 0, 0, 5, 5};
-  slotRatios_[ToUnderlying(MagicType::BufGaugeCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 5, 5};
-  slotRatios_[ToUnderlying(MagicType::BufSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
-  slotRatios_[ToUnderlying(MagicType::BufSpeedCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
+  // SPEED/UTILITY ITEMS (Group 3) - MagicSlotRatio (Table 199)
+  slotRatios_[ToUnderlying(MagicType::Booster)].rankWeights = {0, 0, 0, 10, 20, 40, 70, 70};
+  slotRatios_[ToUnderlying(MagicType::BoosterCritical)].rankWeights = {0, 0, 0, 10, 20, 40, 70, 70};
+  slotRatios_[ToUnderlying(MagicType::HotRodding)].rankWeights = {0, 0, 0, 0, 0, 0, 10, 30};
+  slotRatios_[ToUnderlying(MagicType::HotRoddingCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 10, 30};
+  
+  // MagicGroupTeamAssistanceRatio (Table 278)
+  slotRatios_[ToUnderlying(MagicType::BufPower)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
+  slotRatios_[ToUnderlying(MagicType::BufPowerCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
+  slotRatios_[ToUnderlying(MagicType::BufGauge)].rankWeights = {0, 0, 0, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::BufGaugeCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 0, 0};
+  slotRatios_[ToUnderlying(MagicType::BufSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 80, 80};
+  slotRatios_[ToUnderlying(MagicType::BufSpeedCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 80, 80};
 
-  // OFFENSIVE ITEMS (Group 1)
-  // Directly from MagicGroupAttackRatio (Table 217):
-  // Type 2 (FireBall):  0-15-15-10-10-25-5-10
-  // Type 14 (DarkFire): 0-20-17-10-10-15-10-10
-  // Type 16 (Summon):   0-5-15-15-15-10-10-5
-  // Type 12 (JumpStun): 0-0-0-0-5-25-0-0
-  // Type 18 (Lightning): NOT in table -> use legacy reduced weight
-
-  // FireBall - directly from MagicGroupAttackRatio
+  // OFFENSIVE ITEMS (Group 1) - MagicGroupAttackRatio (Table 217)
   slotRatios_[ToUnderlying(MagicType::FireBall)].rankWeights = {0, 15, 15, 10, 10, 25, 5, 10};
   slotRatios_[ToUnderlying(MagicType::FireBallCritical)].rankWeights = {0, 15, 15, 10, 10, 25, 5, 10};
 
-  // DarkFire - directly from MagicGroupAttackRatio
   slotRatios_[ToUnderlying(MagicType::DarkFire)].rankWeights = {0, 20, 17, 10, 10, 15, 10, 10};
   slotRatios_[ToUnderlying(MagicType::DarkFireCritical)].rankWeights = {0, 20, 17, 10, 10, 15, 10, 10};
 
-  // Summon - directly from MagicGroupAttackRatio
   slotRatios_[ToUnderlying(MagicType::Summon)].rankWeights = {0, 5, 15, 15, 15, 10, 10, 5};
   slotRatios_[ToUnderlying(MagicType::SummonCritical)].rankWeights = {0, 5, 15, 15, 15, 10, 10, 5};
 
-  // JumpStun - directly from MagicGroupAttackRatio
   slotRatios_[ToUnderlying(MagicType::JumpStun)].rankWeights = {0, 0, 0, 0, 5, 25, 0, 0};
   slotRatios_[ToUnderlying(MagicType::JumpStunCritical)].rankWeights = {0, 0, 0, 0, 5, 25, 0, 0};
 
-  // Lightning - NOT in MagicGroupAttackRatio
-  // Legacy code gives it weight=1 (vs 4 for others), so ~25% of normal offensive items
-  // Since it's not in the attack ratio table, use 25% of FireBall/DarkFire ratios
-  // FireBall: {0, 15, 15, 10, 10, 25, 5, 10}
-  // DarkFire: {0, 20, 17, 10, 10, 15, 10, 10}
-  // Lightning (25% of average): {0, 3, 4, 2, 2, 6, 2, 3}
+  // Lightning (not in Table 217, using average legacy values)
   slotRatios_[ToUnderlying(MagicType::Lightning)].rankWeights = {0, 3, 4, 2, 2, 6, 2, 3};
   slotRatios_[ToUnderlying(MagicType::LightningCritical)].rankWeights = {0, 3, 4, 2, 2, 6, 2, 3};
-
-  // TEAM ASSISTANCE ITEMS
-  slotRatios_[ToUnderlying(MagicType::BufPower)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
-  slotRatios_[ToUnderlying(MagicType::BufPowerCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
 }
 
 void MagicConfig::InitializeTeamModifiers()
@@ -170,18 +163,32 @@ void MagicConfig::InitializeTeamModifiers()
     }
   }
 
+  for (auto& mod : slotTeamModifiers_)
+  {
+    mod = SlotTeamModifier{};
+  }
+
+  // MagicGroupTeamModifier (Table 270)
   teamModifiers_[static_cast<uint32_t>(MagicGroup::Offensive)][0] = {
     .ahead1 = 10, .ahead2 = 10, .ahead3 = 10, .ahead4 = 10, .appliesWhenLeading = false};
   teamModifiers_[static_cast<uint32_t>(MagicGroup::Offensive)][1] = {
     .ahead1 = -10, .ahead2 = -10, .ahead3 = -10, .ahead4 = -10, .appliesWhenLeading = true};
   teamModifiers_[static_cast<uint32_t>(MagicGroup::Defensive)][1] = {
     .ahead1 = 10, .ahead2 = 5, .ahead3 = 0, .ahead4 = 0, .appliesWhenLeading = true};
-  teamModifiers_[static_cast<uint32_t>(MagicGroup::SpeedUtility)][1] = {
-    .ahead1 = 10, .ahead2 = 5, .ahead3 = 0, .ahead4 = 0, .appliesWhenLeading = true};
   teamModifiers_[static_cast<uint32_t>(MagicGroup::RareOffensive)][1] = {
     .ahead1 = -100, .ahead2 = -100, .ahead3 = -100, .ahead4 = -100, .appliesWhenLeading = true};
   teamModifiers_[static_cast<uint32_t>(MagicGroup::RareUtility)][1] = {
     .ahead1 = -10, .ahead2 = -10, .ahead3 = -20, .ahead4 = -20, .appliesWhenLeading = true};
+
+  // MagicSlotTeamModifier (Table 271)
+  slotTeamModifiers_[ToUnderlying(MagicType::BufPower)] = {
+    .ahead1 = 10, .ahead2 = 20, .ahead3 = 30, .ahead4 = 40, .appliesWhenLeading = false};
+  slotTeamModifiers_[ToUnderlying(MagicType::BufPowerCritical)] = {
+    .ahead1 = 10, .ahead2 = 20, .ahead3 = 30, .ahead4 = 40, .appliesWhenLeading = false};
+  slotTeamModifiers_[ToUnderlying(MagicType::BufSpeed)] = {
+    .ahead1 = 10, .ahead2 = 20, .ahead3 = 30, .ahead4 = 40, .appliesWhenLeading = false};
+  slotTeamModifiers_[ToUnderlying(MagicType::BufSpeedCritical)] = {
+    .ahead1 = 10, .ahead2 = 20, .ahead3 = 30, .ahead4 = 40, .appliesWhenLeading = false};
 }
 
 void MagicConfig::InitializeTypeMappings()

--- a/src/server/race/magic/MagicConfig.cpp
+++ b/src/server/race/magic/MagicConfig.cpp
@@ -19,7 +19,7 @@
 
 #include "server/race/magic/MagicConfig.hpp"
 
-namespace server::magic
+namespace server::race::magic
 {
 
 MagicConfig::MagicConfig()
@@ -34,7 +34,7 @@ MagicConfig::MagicConfig()
 void MagicConfig::InitializeAllocationRules()
 {
   // Initialize all rules with default values (allow all ranks and player counts)
-  // Then override specific types with data from MagicAllocInfo.xml
+  // Then override specific types with data from MagicAllocInfo
   for (auto& rule : allocationRules_)
   {
     rule = {
@@ -49,7 +49,7 @@ void MagicConfig::InitializeAllocationRules()
       .conditionValue = 0.0f};
   }
 
-  // Data from MagicAllocInfo.xml (Table 216)
+  // Data from MagicAllocInfo (Table 216)
   // Only types with specific rules are overridden
   allocationRules_[ToUnderlying(MagicType::WaterShieldCritical)] = {
     .minRank = 3,
@@ -85,7 +85,7 @@ void MagicConfig::InitializeGroupRatios()
     ratio = GroupRatio{};
   }
 
-  // Data from MagicGroupRatio.xml (Table 214) - Solo mode
+  // Data from MagicGroupRatio (Table 214) - Solo mode
   soloGroupRatios_[static_cast<uint32_t>(MagicGroup::Offensive)].rankWeights = {0, 45, 60, 65, 65, 60, 44, 11};
   soloGroupRatios_[static_cast<uint32_t>(MagicGroup::Defensive)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
   soloGroupRatios_[static_cast<uint32_t>(MagicGroup::SpeedUtility)].rankWeights = {5, 40, 30, 25, 40, 35, 44, 82};
@@ -94,7 +94,7 @@ void MagicConfig::InitializeGroupRatios()
   soloGroupRatios_[static_cast<uint32_t>(MagicGroup::RareSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 4, 11};
   soloGroupRatios_[static_cast<uint32_t>(MagicGroup::RareUtility)].rankWeights = {0, 0, 0, 0, 0, 0, 22, 22};
 
-  // Data from MagicGroupTeamRatio.xml (Table 355) - Team mode
+  // Data from MagicGroupTeamRatio (Table 355) - Team mode
   teamGroupRatios_[static_cast<uint32_t>(MagicGroup::Offensive)].rankWeights = {0, 45, 50, 65, 65, 60, 44, 11};
   teamGroupRatios_[static_cast<uint32_t>(MagicGroup::Defensive)].rankWeights = {60, 15, 0, 0, 0, 0, 0, 0};
   teamGroupRatios_[static_cast<uint32_t>(MagicGroup::SpeedUtility)].rankWeights = {5, 40, 30, 25, 40, 35, 44, 82};
@@ -115,18 +115,18 @@ void MagicConfig::InitializeSlotRatios()
     ratio = defaultRatio;
   }
 
-  // DEFENSIVE ITEMS (Group 2) - MagicSlotRatio (Table 199)
+  // Defensive Items (Group 2) - MagicSlotRatio (Table 199)
   slotRatios_[ToUnderlying(MagicType::WaterShield)].rankWeights = {15, 5, 5, 0, 0, 0, 0, 0};
   slotRatios_[ToUnderlying(MagicType::WaterShieldCritical)].rankWeights = {15, 5, 5, 0, 0, 0, 0, 0};
   slotRatios_[ToUnderlying(MagicType::IceWall)].rankWeights = {25, 0, 0, 0, 0, 0, 0, 0};
   slotRatios_[ToUnderlying(MagicType::IceWallCritical)].rankWeights = {25, 0, 0, 0, 0, 0, 0, 0};
 
-  // SPEED/UTILITY ITEMS (Group 3) - MagicSlotRatio (Table 199)
+  // Speed/Utility Items (Group 3) - MagicSlotRatio (Table 199)
   slotRatios_[ToUnderlying(MagicType::Booster)].rankWeights = {0, 0, 0, 10, 20, 40, 70, 70};
   slotRatios_[ToUnderlying(MagicType::BoosterCritical)].rankWeights = {0, 0, 0, 10, 20, 40, 70, 70};
   slotRatios_[ToUnderlying(MagicType::HotRodding)].rankWeights = {0, 0, 0, 0, 0, 0, 10, 30};
   slotRatios_[ToUnderlying(MagicType::HotRoddingCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 10, 30};
-  
+
   // MagicGroupTeamAssistanceRatio (Table 278)
   slotRatios_[ToUnderlying(MagicType::BufPower)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
   slotRatios_[ToUnderlying(MagicType::BufPowerCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 20, 20};
@@ -135,7 +135,7 @@ void MagicConfig::InitializeSlotRatios()
   slotRatios_[ToUnderlying(MagicType::BufSpeed)].rankWeights = {0, 0, 0, 0, 0, 0, 80, 80};
   slotRatios_[ToUnderlying(MagicType::BufSpeedCritical)].rankWeights = {0, 0, 0, 0, 0, 0, 80, 80};
 
-  // OFFENSIVE ITEMS (Group 1) - MagicGroupAttackRatio (Table 217)
+  // Offensive Items (Group 1) - MagicGroupAttackRatio (Table 217)
   slotRatios_[ToUnderlying(MagicType::FireBall)].rankWeights = {0, 15, 15, 10, 10, 25, 5, 10};
   slotRatios_[ToUnderlying(MagicType::FireBallCritical)].rankWeights = {0, 15, 15, 10, 10, 25, 5, 10};
 
@@ -263,8 +263,8 @@ std::vector<MagicType> MagicConfig::GetValidTypesForContext(const RaceContext& c
 
     const AllocationRule* rule = GetAllocationRule(type);
 
-    if (rule && (context.totalPlayers < rule->minPlayerCount ||
-                  context.rank < rule->minRank ||
+    if (rule and (context.totalPlayers < rule->minPlayerCount or
+                  context.rank < rule->minRank or
                   context.rank > rule->maxRank))
     {
       continue;
@@ -276,4 +276,4 @@ std::vector<MagicType> MagicConfig::GetValidTypesForContext(const RaceContext& c
   return validTypes;
 }
 
-} // namespace server::magic
+} // namespace server::race::magic

--- a/src/server/race/magic/MagicConfig.cpp
+++ b/src/server/race/magic/MagicConfig.cpp
@@ -62,7 +62,7 @@ void MagicConfig::InitializeAllocationRules()
     .conditionType = 1,
     .conditionValue = 200.0f};
 
-  allocationRules_[ToUnderlying(MagicType::Booster)] = {
+  allocationRules_[ToUnderlying(MagicType::BoosterCritical)] = {
     .minRank = 7,
     .maxRank = 8,
     .minPlayerCount = 3,

--- a/src/server/race/magic/MagicSelector.cpp
+++ b/src/server/race/magic/MagicSelector.cpp
@@ -47,6 +47,7 @@ registry::Magic::SlotInfo MagicSelector::SelectItem(
 
   // Build context
   RaceContext context = BuildContext(positionInfo, totalActiveRacers);
+  context.isTeamMode = (racer.team != tracker::RaceTracker::Racer::Team::Solo);
   spdlog::debug("Context: rank={}, totalPlayers={}, aheadCount={}, isLeading={}, isTeamMode={}",
     context.rank,
     context.totalPlayers,
@@ -107,7 +108,7 @@ registry::Magic::SlotInfo MagicSelector::SelectItem(
     }());
 
   // Layer 2: Select group by normalized rank (scales with race size)
-  MagicGroup selectedGroup = SelectGroupByRank(context.normalizedRank);
+  MagicGroup selectedGroup = SelectGroupByRank(context.normalizedRank, context.isTeamMode);
   context.group = selectedGroup;
 
   spdlog::debug("Rank={}, normalizedRank={}, selectedGroup={}",
@@ -155,7 +156,7 @@ registry::Magic::SlotInfo MagicSelector::SelectItem(
       if (group == selectedGroup)
         continue;
 
-      const GroupRatio* ratio = config.GetGroupRatio(group);
+      const GroupRatio* ratio = config.GetGroupRatio(group, context.isTeamMode);
       if (ratio && ratio->rankWeights[context.normalizedRank - 1] > 0)
       {
         alternativeGroups.emplace_back(group, ratio->rankWeights[context.normalizedRank - 1]);
@@ -244,7 +245,7 @@ registry::Magic::SlotInfo MagicSelector::SelectItem(
       if (group == selectedGroup)
         continue;
 
-      const GroupRatio* ratio = config.GetGroupRatio(group);
+      const GroupRatio* ratio = config.GetGroupRatio(group, context.isTeamMode);
       if (ratio && ratio->rankWeights[context.normalizedRank - 1] > 0)
       {
         alternativeGroups.emplace_back(group, ratio->rankWeights[context.normalizedRank - 1]);
@@ -364,13 +365,13 @@ registry::Magic::SlotInfo MagicSelector::SelectItem(
 // PRIVATE IMPLEMENTATION
 // ============================================================================
 
-MagicGroup MagicSelector::SelectGroupByRank(uint32_t rank) const
+MagicGroup MagicSelector::SelectGroupByRank(uint32_t rank, bool isTeamMode) const
 {
   // Use normalized rank if provided (from RaceContext), otherwise use the raw rank
   // This allows for consistent distribution across different race sizes
   const auto& config = MagicConfig::GetInstance();
 
-  // Use MagicGroupTeamRatio data (Table 355) for weighted group selection
+  // Use MagicGroupRatio or MagicGroupTeamRatio data for weighted group selection
   // This defines the probability percentage for each group at each rank
   // We need to select a group based on these weights
 
@@ -380,14 +381,14 @@ MagicGroup MagicSelector::SelectGroupByRank(uint32_t rank) const
   if (rank > 8)
     rank = 8;
 
-  // Build weighted group selection based on MagicGroupTeamRatio
+  // Build weighted group selection based on group ratios
   // Only include groups that have non-zero weight for this rank
   std::vector<std::pair<MagicGroup, uint32_t>> groupWeights;
 
   for (uint32_t g = 1; g < static_cast<uint32_t>(MagicGroup::MaxGroups); ++g)
   {
     MagicGroup group = static_cast<MagicGroup>(g);
-    const GroupRatio* ratio = config.GetGroupRatio(group);
+    const GroupRatio* ratio = config.GetGroupRatio(group, isTeamMode);
 
     if (ratio && ratio->rankWeights[rank - 1] > 0)
     {
@@ -495,7 +496,7 @@ std::vector<std::pair<MagicType, uint32_t>> MagicSelector::ApplySlotRatios(
 
     // Handle team assistance items (BufPower=20, BufGauge=22, BufSpeed=24)
     // These have special ratios from MagicGroupTeamAssistanceRatio
-    if (underlyingType == 20 || underlyingType == 22 || underlyingType == 24)
+    if (underlyingType >= 20 && underlyingType <= 25)
     {
       // For team items, check if rank allows them
       // BufPower (20): ranks 7-8 only, 20% each
@@ -602,6 +603,41 @@ void MagicSelector::ApplyDynamicModifiers(
 
       // Apply modifier as percentage (negative values reduce, positive increase)
       // Convert modValue to a multiplier: -10 = -10%, +10 = +10%
+      int32_t adjustedWeight = static_cast<int32_t>(weight) +
+                               static_cast<int32_t>((weight * modValue) / 100);
+
+      // Ensure weight doesn't go negative
+      weight = static_cast<uint32_t>(std::max(1, adjustedWeight));
+    }
+
+    // Get slot team modifier for this type
+    const SlotTeamModifier* slotModifier = config.GetSlotTeamModifier(type);
+
+    if (slotModifier && slotModifier->appliesWhenLeading == context.isLeading)
+    {
+      // Apply modifier based on how many players are ahead
+      int32_t modValue = 0;
+
+      switch (context.aheadCount)
+      {
+        case 1:
+          modValue = slotModifier->ahead1;
+          break;
+        case 2:
+          modValue = slotModifier->ahead2;
+          break;
+        case 3:
+          modValue = slotModifier->ahead3;
+          break;
+        case 4:
+          modValue = slotModifier->ahead4;
+          break;
+        default:
+          modValue = 0;
+          break;
+      }
+
+      // Apply modifier as percentage
       int32_t adjustedWeight = static_cast<int32_t>(weight) +
                                static_cast<int32_t>((weight * modValue) / 100);
 

--- a/src/server/race/magic/MagicSelector.cpp
+++ b/src/server/race/magic/MagicSelector.cpp
@@ -21,19 +21,16 @@
 
 #include <algorithm>
 #include <numeric>
+
 #include <spdlog/spdlog.h>
 
-namespace server::magic
+namespace server::race::magic
 {
 
 MagicSelector::MagicSelector(const registry::MagicRegistry& magicRegistry)
   : _magicRegistry(magicRegistry)
 {
 }
-
-// ============================================================================
-// PUBLIC API
-// ============================================================================
 
 registry::Magic::SlotInfo MagicSelector::SelectItem(
   const tracker::RaceTracker::Racer& racer,
@@ -360,10 +357,6 @@ registry::Magic::SlotInfo MagicSelector::SelectItem(
   uint32_t totalActiveRacers = static_cast<uint32_t>(racePositions.size());
   return SelectItem(racer, *positionIt, totalActiveRacers);
 }
-
-// ============================================================================
-// PRIVATE IMPLEMENTATION
-// ============================================================================
 
 MagicGroup MagicSelector::SelectGroupByRank(uint32_t rank, bool isTeamMode) const
 {
@@ -820,4 +813,4 @@ registry::Magic::SlotInfo MagicSelector::HandleCriticalChance(
   return slotInfo;
 }
 
-} // namespace server::magic
+} // namespace server::race::magic

--- a/src/server/race/magic/MagicSelector.cpp
+++ b/src/server/race/magic/MagicSelector.cpp
@@ -1,0 +1,782 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2026 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#include "server/race/magic/MagicSelector.hpp"
+
+#include <algorithm>
+#include <numeric>
+#include <spdlog/spdlog.h>
+
+namespace server::magic
+{
+
+MagicSelector::MagicSelector(const registry::MagicRegistry& magicRegistry)
+  : _magicRegistry(magicRegistry)
+{
+}
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+registry::Magic::SlotInfo MagicSelector::SelectItem(
+  const tracker::RaceTracker::Racer& racer,
+  const tracker::RaceTracker::RacerPositionInfo& positionInfo,
+  uint32_t totalActiveRacers) const
+{
+  spdlog::debug("Selecting magic item for racer: rank={}, trackProgress={:.7f}, totalRacers={}",
+    positionInfo.rank,
+    positionInfo.trackProgress,
+    totalActiveRacers);
+
+  // Build context
+  RaceContext context = BuildContext(positionInfo, totalActiveRacers);
+  spdlog::debug("Context: rank={}, totalPlayers={}, aheadCount={}, isLeading={}, isTeamMode={}",
+    context.rank,
+    context.totalPlayers,
+    context.aheadCount,
+    context.isLeading,
+    context.isTeamMode);
+
+  // Layer 0: Get the pool based on team mode
+  const auto& pool = GetItemPool(racer);
+
+  // Layer 1: Filter pool items by allocation rules (using normalized rank for scaling)
+  std::vector<MagicType> validTypes;
+  for (uint32_t poolType : pool)
+  {
+    MagicType type = static_cast<MagicType>(poolType);
+
+    // Skip invalid types
+    if (type == MagicType::Invalid || type >= MagicType::MaxTypes)
+      continue;
+
+    // Check allocation rules using normalized rank for proper scaling
+    const auto& config = MagicConfig::GetInstance();
+    const AllocationRule* rule = config.GetAllocationRule(type);
+
+    if (rule && (context.totalPlayers < rule->minPlayerCount ||
+                  context.normalizedRank < rule->minRank ||
+                  context.normalizedRank > rule->maxRank))
+    {
+      continue; // Item excluded by allocation rules
+    }
+
+    validTypes.push_back(type);
+  }
+
+  if (validTypes.empty())
+  {
+    spdlog::warn("No valid magic types for context: rank={}, totalRacers={}",
+      context.rank,
+      context.totalPlayers);
+    // Fallback: return first item from pool
+    if (!pool.empty())
+    {
+      return _magicRegistry.GetSlotInfo(pool[0]);
+    }
+    throw std::runtime_error("No magic items available");
+  }
+
+  spdlog::debug("Valid types for rank {}: {}", context.rank, [&]()
+    {
+      std::string result;
+      for (MagicType t : validTypes)
+      {
+        if (!result.empty())
+          result += ", ";
+        result += std::to_string(ToUnderlying(t));
+      }
+      return result;
+    }());
+
+  // Layer 2: Select group by normalized rank (scales with race size)
+  MagicGroup selectedGroup = SelectGroupByRank(context.normalizedRank);
+  context.group = selectedGroup;
+
+  spdlog::debug("Rank={}, normalizedRank={}, selectedGroup={}",
+    context.rank,
+    context.normalizedRank,
+    static_cast<int>(selectedGroup));
+  spdlog::debug("Selected group for rank {}: {}", context.rank, static_cast<int>(selectedGroup));
+
+  // Layer 3: Filter to only items in the selected group, then apply slot ratios
+  const auto& config = MagicConfig::GetInstance();
+  std::vector<MagicType> groupTypes;
+  for (MagicType type : validTypes)
+  {
+    MagicGroup typeGroup = config.GetGroupForType(type);
+    if (typeGroup == selectedGroup)
+    {
+      groupTypes.push_back(type);
+    }
+  }
+
+  spdlog::debug("Group {} types: {}", static_cast<int>(selectedGroup), [&]()
+    {
+      std::string result;
+      for (MagicType t : groupTypes)
+      {
+        if (!result.empty())
+          result += ", ";
+        result += std::to_string(ToUnderlying(t));
+      }
+      return result;
+    }());
+
+  // If no types in the selected group, try to select a different group that has items
+  if (groupTypes.empty())
+  {
+    spdlog::debug("No items found for selectedGroup={}, trying alternative groups",
+      static_cast<int>(selectedGroup));
+
+    // Try other groups in order of their weight for this normalized rank
+    // Get all groups sorted by weight for this normalized rank
+    std::vector<std::pair<MagicGroup, uint32_t>> alternativeGroups;
+    for (uint32_t g = 1; g < static_cast<uint32_t>(MagicGroup::MaxGroups); ++g)
+    {
+      MagicGroup group = static_cast<MagicGroup>(g);
+      if (group == selectedGroup)
+        continue;
+
+      const GroupRatio* ratio = config.GetGroupRatio(group);
+      if (ratio && ratio->rankWeights[context.normalizedRank - 1] > 0)
+      {
+        alternativeGroups.emplace_back(group, ratio->rankWeights[context.normalizedRank - 1]);
+      }
+    }
+
+    // Sort by weight descending
+    std::sort(alternativeGroups.begin(), alternativeGroups.end(), [](const auto& a, const auto& b)
+      {
+        return a.second > b.second;
+      });
+
+    // Try each alternative group until we find one with items
+    for (const auto& [altGroup, weight] : alternativeGroups)
+    {
+      std::vector<MagicType> altGroupTypes;
+      for (MagicType type : validTypes)
+      {
+        if (config.GetGroupForType(type) == altGroup)
+        {
+          altGroupTypes.push_back(type);
+        }
+      }
+
+      if (!altGroupTypes.empty())
+      {
+        groupTypes = altGroupTypes;
+        selectedGroup = altGroup;
+        context.group = altGroup;
+        spdlog::debug("Found items in alternative group={}", static_cast<int>(altGroup));
+        break;
+      }
+    }
+
+    // If still no types found, fall back to all valid types
+    if (groupTypes.empty())
+    {
+      spdlog::warn("No items found in any group for rank={}, falling back to all valid types",
+        context.rank);
+      groupTypes = validTypes;
+      spdlog::debug("Fallback: using all valid types: {}",
+        [&]()
+        {
+          std::string result;
+          for (MagicType t : groupTypes)
+          {
+            if (!result.empty())
+              result += ", ";
+            result += std::to_string(ToUnderlying(t));
+          }
+          return result;
+        }());
+    }
+    else
+    {
+      spdlog::debug("Using alternative group={}, types: {}", static_cast<int>(selectedGroup), [&]()
+        {
+          std::string result;
+          for (MagicType t : groupTypes)
+          {
+            if (!result.empty())
+              result += ", ";
+            result += std::to_string(ToUnderlying(t));
+          }
+          return result;
+        }());
+    }
+  }
+
+  // Apply slot ratios to items in the selected group (using normalized rank)
+  std::vector<std::pair<MagicType, uint32_t>> weightedTypes =
+    ApplySlotRatios(groupTypes, context.normalizedRank, totalActiveRacers);
+
+  // If all items in the group have 0 weight for this normalized rank, try alternative groups
+  if (weightedTypes.empty() && !groupTypes.empty())
+  {
+    spdlog::debug("All items in group {} have 0 weight for normalized rank {}, trying alternative groups",
+      static_cast<int>(selectedGroup),
+      context.normalizedRank);
+
+    // Try other groups in order of their weight for this normalized rank
+    std::vector<std::pair<MagicGroup, uint32_t>> alternativeGroups;
+    for (uint32_t g = 1; g < static_cast<uint32_t>(MagicGroup::MaxGroups); ++g)
+    {
+      MagicGroup group = static_cast<MagicGroup>(g);
+      if (group == selectedGroup)
+        continue;
+
+      const GroupRatio* ratio = config.GetGroupRatio(group);
+      if (ratio && ratio->rankWeights[context.normalizedRank - 1] > 0)
+      {
+        alternativeGroups.emplace_back(group, ratio->rankWeights[context.normalizedRank - 1]);
+      }
+    }
+
+    // Sort by weight descending
+    std::sort(alternativeGroups.begin(), alternativeGroups.end(), [](const auto& a, const auto& b)
+      {
+        return a.second > b.second;
+      });
+
+    // Try each alternative group until we find one with non-zero weight items
+    for (const auto& [altGroup, weight] : alternativeGroups)
+    {
+      std::vector<MagicType> altGroupTypes;
+      for (MagicType type : validTypes)
+      {
+        if (config.GetGroupForType(type) == altGroup)
+        {
+          altGroupTypes.push_back(type);
+        }
+      }
+
+      std::vector<std::pair<MagicType, uint32_t>> altWeightedTypes =
+        ApplySlotRatios(altGroupTypes, context.normalizedRank, totalActiveRacers);
+
+      if (!altWeightedTypes.empty())
+      {
+        weightedTypes = altWeightedTypes;
+        selectedGroup = altGroup;
+        context.group = altGroup;
+        spdlog::debug("Found items in alternative group={} with non-zero weights", static_cast<int>(altGroup));
+        break;
+      }
+    }
+
+    // If still no types found, fall back to all valid types
+    if (weightedTypes.empty())
+    {
+      spdlog::warn("No items found in any group for normalized rank={} after weight filtering, falling back to all valid types",
+        context.normalizedRank);
+      weightedTypes = ApplySlotRatios(validTypes, context.normalizedRank, totalActiveRacers);
+    }
+  }
+
+  // Layer 4: Apply dynamic modifiers
+  ApplyDynamicModifiers(weightedTypes, context);
+
+  // Select final type
+  MagicType selectedType = SelectFromWeighted(weightedTypes);
+
+  // Get slot info and handle critical chance
+  registry::Magic::SlotInfo slotInfo = _magicRegistry.GetSlotInfo(ToUnderlying(selectedType));
+  slotInfo = HandleCriticalChance(slotInfo, racer);
+
+  // Get the actual group of the selected item for logging
+  MagicGroup actualGroup = config.GetGroupForType(selectedType);
+
+  spdlog::debug("Selected magic item: rank={}/{}, normalized={}, type={}, basicType={}, selectedGroup={}, actualGroup={}",
+    context.rank,
+    context.totalPlayers,
+    context.normalizedRank,
+    slotInfo.type,
+    slotInfo.basicType,
+    static_cast<int>(selectedGroup),
+    static_cast<int>(actualGroup));
+
+  return slotInfo;
+}
+
+registry::Magic::SlotInfo MagicSelector::SelectItem(
+  const tracker::RaceTracker::Racer& racer,
+  data::Uid characterUid,
+  const std::vector<tracker::RaceTracker::RacerPositionInfo>& racePositions) const
+{
+  if (racePositions.empty())
+  {
+    spdlog::warn("No position info available, falling back to random selection");
+    // Fallback to simple random
+    const auto& pool = GetItemPool(racer);
+    if (!pool.empty())
+    {
+      std::uniform_int_distribution<size_t> dist(0, pool.size() - 1);
+      uint32_t randomType = pool[dist(_randomDevice)];
+      registry::Magic::SlotInfo slotInfo = _magicRegistry.GetSlotInfo(randomType);
+      return HandleCriticalChance(slotInfo, racer);
+    }
+    throw std::runtime_error("No magic items available");
+  }
+
+  // Find this racer's position
+  auto positionIt = std::find_if(racePositions.begin(), racePositions.end(), [characterUid](const auto& pos)
+    {
+      return pos.characterUid == characterUid;
+    });
+
+  if (positionIt == racePositions.end())
+  {
+    spdlog::warn("Racer {} not found in position list", characterUid);
+    const auto& pool = GetItemPool(racer);
+    if (!pool.empty())
+    {
+      std::uniform_int_distribution<size_t> dist(0, pool.size() - 1);
+      uint32_t randomType = pool[dist(_randomDevice)];
+      registry::Magic::SlotInfo slotInfo = _magicRegistry.GetSlotInfo(randomType);
+      return HandleCriticalChance(slotInfo, racer);
+    }
+    throw std::runtime_error("Racer not found in position list");
+  }
+
+  uint32_t totalActiveRacers = static_cast<uint32_t>(racePositions.size());
+  return SelectItem(racer, *positionIt, totalActiveRacers);
+}
+
+// ============================================================================
+// PRIVATE IMPLEMENTATION
+// ============================================================================
+
+MagicGroup MagicSelector::SelectGroupByRank(uint32_t rank) const
+{
+  // Use normalized rank if provided (from RaceContext), otherwise use the raw rank
+  // This allows for consistent distribution across different race sizes
+  const auto& config = MagicConfig::GetInstance();
+
+  // Use MagicGroupTeamRatio data (Table 355) for weighted group selection
+  // This defines the probability percentage for each group at each rank
+  // We need to select a group based on these weights
+
+  // Clamp rank to valid range [1, 8]
+  if (rank < 1)
+    rank = 1;
+  if (rank > 8)
+    rank = 8;
+
+  // Build weighted group selection based on MagicGroupTeamRatio
+  // Only include groups that have non-zero weight for this rank
+  std::vector<std::pair<MagicGroup, uint32_t>> groupWeights;
+
+  for (uint32_t g = 1; g < static_cast<uint32_t>(MagicGroup::MaxGroups); ++g)
+  {
+    MagicGroup group = static_cast<MagicGroup>(g);
+    const GroupRatio* ratio = config.GetGroupRatio(group);
+
+    if (ratio && ratio->rankWeights[rank - 1] > 0)
+    {
+      // Store the weight directly (these are already percentages)
+      groupWeights.emplace_back(group, ratio->rankWeights[rank - 1]);
+    }
+  }
+
+  // If no groups have weights, use fallback
+  if (groupWeights.empty())
+  {
+    // Ranks 1-2: Defensive (Group 2)
+    // Ranks 7-8: SpeedUtility (Group 3)
+    // Others: Offensive (Group 1)
+    if (rank <= 2)
+    {
+      return MagicGroup::Defensive;
+    }
+    else if (rank >= 7)
+    {
+      return MagicGroup::SpeedUtility;
+    }
+    else
+    {
+      return MagicGroup::Offensive;
+    }
+  }
+
+  // Select group using weighted random based on the weights
+  return SelectGroupFromWeighted(groupWeights);
+}
+
+MagicGroup MagicSelector::SelectGroupFromWeighted(
+  const std::vector<std::pair<MagicGroup, uint32_t>>& groupWeights) const
+{
+
+  if (groupWeights.empty())
+  {
+    return MagicGroup::Offensive;
+  }
+
+  // Calculate total weight
+  uint32_t totalWeight = 0;
+  for (const auto& [group, weight] : groupWeights)
+  {
+    totalWeight += weight;
+  }
+
+  if (totalWeight == 0)
+  {
+    // Uniform selection
+    std::uniform_int_distribution<size_t> dist(0, groupWeights.size() - 1);
+    return groupWeights[dist(_randomDevice)].first;
+  }
+
+  // Build cumulative distribution
+  std::vector<uint32_t> cumulativeWeights;
+  cumulativeWeights.reserve(groupWeights.size());
+  uint32_t runningSum = 0;
+
+  for (const auto& [group, weight] : groupWeights)
+  {
+    runningSum += weight;
+    cumulativeWeights.push_back(runningSum);
+  }
+
+  // Select random value
+  std::uniform_int_distribution<uint32_t> dist(1, totalWeight);
+  uint32_t randomValue = dist(_randomDevice);
+
+  // Find selected group
+  for (size_t i = 0; i < cumulativeWeights.size(); ++i)
+  {
+    if (randomValue <= cumulativeWeights[i])
+    {
+      return groupWeights[i].first;
+    }
+  }
+
+  // Fallback to last element
+  return groupWeights.back().first;
+}
+
+std::vector<std::pair<MagicType, uint32_t>> MagicSelector::ApplySlotRatios(
+  const std::vector<MagicType>& types,
+  uint32_t rank,
+  uint32_t /*totalRacers*/) const
+{
+
+  const auto& config = MagicConfig::GetInstance();
+  std::vector<std::pair<MagicType, uint32_t>> weightedTypes;
+
+  for (MagicType type : types)
+  {
+    uint32_t underlyingType = ToUnderlying(type);
+
+    // Get slot ratio for this type
+    const SlotRatio* slotRatio = config.GetSlotRatio(type);
+    uint32_t rankWeight = 100; // Default weight
+
+    if (slotRatio && rank >= 1 && rank <= 8)
+    {
+      rankWeight = slotRatio->rankWeights[rank - 1];
+    }
+
+    // Handle team assistance items (BufPower=20, BufGauge=22, BufSpeed=24)
+    // These have special ratios from MagicGroupTeamAssistanceRatio
+    if (underlyingType == 20 || underlyingType == 22 || underlyingType == 24)
+    {
+      // For team items, check if rank allows them
+      // BufPower (20): ranks 7-8 only, 20% each
+      // BufSpeed (24): ranks 7-8 only, 80% each
+      if (rank >= 7)
+      {
+        if (underlyingType == 20 || underlyingType == 21)
+        {
+          rankWeight = 20; // BufPower and critical
+        }
+        else if (underlyingType == 24 || underlyingType == 25)
+        {
+          rankWeight = 80; // BufSpeed and critical
+        }
+        else
+        {
+          rankWeight = 0; // BufGauge not available
+        }
+      }
+      else
+      {
+        rankWeight = 0; // Team assistance items only for ranks 7-8
+      }
+    }
+
+    // Handle offensive items with MagicGroupAttackRatio
+    MagicGroup group = config.GetGroupForType(type);
+    if (group == MagicGroup::Offensive || group == MagicGroup::RareOffensive)
+    {
+      // From MagicGroupAttackRatio:
+      // Type 2 (FireBall): ranks 2-3 have 15%, rank 4-5 have 10%, rank 6 has 25%
+      // Type 14 (DarkFire): ranks 2-3 have 20-17%, rank 4-5 have 10%, rank 6 has 15%
+      // Type 16 (Summon): ranks 2-5 have 5-15%, rank 6 has 10%
+      // Type 12 (JumpStun): rank 5-6 have 5%
+
+      // Apply additional weighting based on attack type ratios
+      // This fine-tunes the offensive items within the group
+      // For now, we'll use the slotRatio which already incorporates this
+      if (rank >= 1 && rank <= 8)
+      {
+        // Get attack ratio for this basic type if available
+        // But we can add additional modifiers
+      }
+    }
+
+    // Convert percentage (0-100) to weight
+    // If rankWeight is 0, the item is not available for this rank
+    if (rankWeight == 0)
+    {
+      spdlog::debug("Type {} has 0 weight for rank {}, skipping", ToUnderlying(type), rank);
+      continue;
+    }
+
+    uint32_t finalWeight = rankWeight;
+
+    weightedTypes.emplace_back(type, finalWeight);
+  }
+
+  return weightedTypes;
+}
+
+void MagicSelector::ApplyDynamicModifiers(
+  std::vector<std::pair<MagicType, uint32_t>>& weightedTypes,
+  const RaceContext& context) const
+{
+
+  const auto& config = MagicConfig::GetInstance();
+
+  for (auto& [type, weight] : weightedTypes)
+  {
+    if (weight == 0)
+      continue;
+
+    MagicGroup group = config.GetGroupForType(type);
+    if (group == MagicGroup::Invalid)
+      continue;
+
+    // Get team modifier for this group
+    const TeamModifier* modifier = config.GetTeamModifier(group, context.isLeading);
+
+    if (modifier && modifier->appliesWhenLeading == context.isLeading)
+    {
+      // Apply modifier based on how many players are ahead
+      int32_t modValue = 0;
+
+      switch (context.aheadCount)
+      {
+        case 1:
+          modValue = modifier->ahead1;
+          break;
+        case 2:
+          modValue = modifier->ahead2;
+          break;
+        case 3:
+          modValue = modifier->ahead3;
+          break;
+        case 4:
+          modValue = modifier->ahead4;
+          break;
+        default:
+          modValue = 0;
+          break;
+      }
+
+      // Apply modifier as percentage (negative values reduce, positive increase)
+      // Convert modValue to a multiplier: -10 = -10%, +10 = +10%
+      int32_t adjustedWeight = static_cast<int32_t>(weight) +
+                               static_cast<int32_t>((weight * modValue) / 100);
+
+      // Ensure weight doesn't go negative
+      weight = static_cast<uint32_t>(std::max(1, adjustedWeight));
+    }
+
+    // Special handling for certain groups
+    if (context.isLeading && group == MagicGroup::Defensive)
+    {
+      // Leaders get bonus to defensive items
+      weight = static_cast<uint32_t>(weight * 1.2f);
+    }
+    else if (!context.isLeading && group == MagicGroup::Offensive)
+    {
+      // Non-leaders get bonus to offensive items
+      weight = static_cast<uint32_t>(weight * 1.1f);
+    }
+  }
+}
+
+MagicType MagicSelector::SelectFromWeighted(
+  const std::vector<std::pair<MagicType, uint32_t>>& weightedTypes) const
+{
+
+  if (weightedTypes.empty())
+  {
+    throw std::runtime_error("No weighted types to select from");
+  }
+
+  // Calculate total weight
+  uint32_t totalWeight = std::accumulate(weightedTypes.begin(), weightedTypes.end(), 0u, [](uint32_t sum, const auto& pair)
+    {
+      return sum + pair.second;
+    });
+
+  if (totalWeight == 0)
+  {
+    // All weights are zero, select uniformly
+    std::uniform_int_distribution<size_t> dist(0, weightedTypes.size() - 1);
+    return weightedTypes[dist(_randomDevice)].first;
+  }
+
+  // Build cumulative distribution
+  std::vector<uint32_t> cumulativeWeights;
+  cumulativeWeights.reserve(weightedTypes.size());
+  uint32_t runningSum = 0;
+
+  for (const auto& [type, weight] : weightedTypes)
+  {
+    runningSum += weight;
+    cumulativeWeights.push_back(runningSum);
+  }
+
+  // Select random value
+  std::uniform_int_distribution<uint32_t> dist(1, totalWeight);
+  uint32_t randomValue = dist(_randomDevice);
+
+  // Find selected type
+  for (size_t i = 0; i < cumulativeWeights.size(); ++i)
+  {
+    if (randomValue <= cumulativeWeights[i])
+    {
+      return weightedTypes[i].first;
+    }
+  }
+
+  // Fallback to last element (shouldn't happen)
+  return weightedTypes.back().first;
+}
+
+uint32_t MagicSelector::NormalizeRank(uint32_t rank, uint32_t totalPlayers) const
+{
+  // If only 1 player, always use rank 1
+  if (totalPlayers <= 1)
+  {
+    return 1;
+  }
+
+  // Normalize rank from [1, totalPlayers] to [1, 8]
+  // This ensures last place (rank N) maps to normalized rank 8,
+  // and first place (rank 1) maps to normalized rank 1.
+  // The formula: normalized = 1 + (rank-1) * 7 / (totalPlayers-1)
+  //
+  // Examples:
+  // - 4 players: rank 1->1, rank 2->3, rank 3->5, rank 4->8
+  // - 8 players: rank 1->1, rank 2->2, rank 3->3, ..., rank 8->8
+  // - 2 players: rank 1->1, rank 2->8
+
+  float ratio = static_cast<float>(rank - 1) / (totalPlayers - 1);
+  return 1 + static_cast<uint32_t>(ratio * 7.0f);
+}
+
+RaceContext MagicSelector::BuildContext(
+  const tracker::RaceTracker::RacerPositionInfo& positionInfo,
+  uint32_t totalActiveRacers) const
+{
+
+  RaceContext context;
+  context.rank = positionInfo.rank;
+  context.totalPlayers = totalActiveRacers;
+  context.aheadCount = context.rank - 1; // Number of players ahead
+  context.isLeading = (context.rank == 1);
+  context.isTeamMode = false; // Will be set based on racer
+  context.group = MagicGroup::Invalid;
+
+  // Calculate normalized rank for consistent distribution across race sizes
+  context.normalizedRank = NormalizeRank(context.rank, totalActiveRacers);
+
+  return context;
+}
+
+const std::vector<uint32_t>& MagicSelector::GetItemPool(
+  const tracker::RaceTracker::Racer& racer) const
+{
+
+  using Team = tracker::RaceTracker::Racer::Team;
+
+  if (racer.team == Team::Solo)
+  {
+    return _magicRegistry.GetSoloPool();
+  }
+  else
+  {
+    return _magicRegistry.GetTeamPool();
+  }
+}
+
+registry::Magic::SlotInfo MagicSelector::HandleCriticalChance(
+  registry::Magic::SlotInfo slotInfo,
+  const tracker::RaceTracker::Racer& racer) const
+{
+
+  // Only apply critical chance if there's a critical version available
+  if (slotInfo.criticalType == 0)
+  {
+    return slotInfo;
+  }
+
+  uint32_t critChanceBp = _magicRegistry.GetBaseCritChanceBp();
+
+  // Apply stat scaling if available
+  if (const auto* scaling = _magicRegistry.GetStatScaling(slotInfo.basicType))
+  {
+    // Get mount stat value
+    uint32_t statValue = 0;
+    switch (scaling->stat)
+    {
+      case registry::Magic::MountStat::Agility:
+        statValue = racer.mountStats.agility;
+        break;
+      case registry::Magic::MountStat::Ambition:
+        statValue = racer.mountStats.ambition;
+        break;
+      case registry::Magic::MountStat::Rush:
+        statValue = racer.mountStats.rush;
+        break;
+      case registry::Magic::MountStat::Endurance:
+        statValue = racer.mountStats.endurance;
+        break;
+      case registry::Magic::MountStat::Courage:
+        statValue = racer.mountStats.courage;
+        break;
+    }
+
+    critChanceBp += scaling->critStepBp * (statValue / 10u);
+  }
+
+  // Roll for critical
+  if ((rand() % 10000) < static_cast<int>(critChanceBp))
+  {
+    slotInfo = _magicRegistry.GetSlotInfo(slotInfo.criticalType);
+  }
+
+  return slotInfo;
+}
+
+} // namespace server::magic

--- a/src/server/race/magic/MagicSelector.cpp
+++ b/src/server/race/magic/MagicSelector.cpp
@@ -712,21 +712,17 @@ uint32_t MagicSelector::NormalizeRank(uint32_t rank, uint32_t totalPlayers) cons
 
   rank = std::clamp(rank, 1u, totalPlayers);
 
-  // The XML tables are 8-position tables, but they should not be stretched
-  // linearly for very small races. In a 1v1, the trailing racer is last, but
-  // treating it as normalized rank 8 makes it behave like 8th of 8 and gives
-  // rank-8 catch-up items such as Booster/HotRodding far too often. Clamp the
-  // normalized scale so 2-player races use the rank-2 part of the tables.
-  if (totalPlayers == 2)
+  // Map the actual position to one of the 8 weight slots [1, 8] via linear interpolation.
+  // This ensures last place in a small race gets "last-place" item weights.
+  uint32_t normalized = rank;
+  if (totalPlayers > 1)
   {
-    return std::clamp(rank, 1u, 2u);
+    normalized = 1u + static_cast<uint32_t>(
+      static_cast<float>(rank - 1) * 7.0f /
+      static_cast<float>(totalPlayers - 1));
   }
 
-  // Normalize rank from [1, totalPlayers] to [1, 8] for larger races.
-  // This keeps 3-player races closer to the official table shape while still
-  // preserving first/last scaling for normal 4-8 player races.
-  float ratio = static_cast<float>(rank - 1) / static_cast<float>(totalPlayers - 1);
-  return std::clamp(1u + static_cast<uint32_t>(ratio * 7.0f), 1u, 8u);
+  return std::clamp(normalized, 1u, 8u);
 }
 
 RaceContext MagicSelector::BuildContext(

--- a/src/server/race/magic/MagicSelector.cpp
+++ b/src/server/race/magic/MagicSelector.cpp
@@ -681,18 +681,23 @@ uint32_t MagicSelector::NormalizeRank(uint32_t rank, uint32_t totalPlayers) cons
     return 1;
   }
 
-  // Normalize rank from [1, totalPlayers] to [1, 8]
-  // This ensures last place (rank N) maps to normalized rank 8,
-  // and first place (rank 1) maps to normalized rank 1.
-  // The formula: normalized = 1 + (rank-1) * 7 / (totalPlayers-1)
-  //
-  // Examples:
-  // - 4 players: rank 1->1, rank 2->3, rank 3->5, rank 4->8
-  // - 8 players: rank 1->1, rank 2->2, rank 3->3, ..., rank 8->8
-  // - 2 players: rank 1->1, rank 2->8
+  rank = std::clamp(rank, 1u, totalPlayers);
 
-  float ratio = static_cast<float>(rank - 1) / (totalPlayers - 1);
-  return 1 + static_cast<uint32_t>(ratio * 7.0f);
+  // The XML tables are 8-position tables, but they should not be stretched
+  // linearly for very small races. In a 1v1, the trailing racer is last, but
+  // treating it as normalized rank 8 makes it behave like 8th of 8 and gives
+  // rank-8 catch-up items such as Booster/HotRodding far too often. Clamp the
+  // normalized scale so 2-player races use the rank-2 part of the tables.
+  if (totalPlayers == 2)
+  {
+    return std::clamp(rank, 1u, 2u);
+  }
+
+  // Normalize rank from [1, totalPlayers] to [1, 8] for larger races.
+  // This keeps 3-player races closer to the official table shape while still
+  // preserving first/last scaling for normal 4-8 player races.
+  float ratio = static_cast<float>(rank - 1) / static_cast<float>(totalPlayers - 1);
+  return std::clamp(1u + static_cast<uint32_t>(ratio * 7.0f), 1u, 8u);
 }
 
 RaceContext MagicSelector::BuildContext(

--- a/src/server/tracker/RaceTracker.cpp
+++ b/src/server/tracker/RaceTracker.cpp
@@ -19,6 +19,10 @@
 
 #include "server/tracker/RaceTracker.hpp"
 
+#include "spdlog/spdlog.h"
+
+#include <algorithm>
+
 namespace server::tracker
 {
 
@@ -171,6 +175,64 @@ void RaceTracker::Clear()
   _events.clear();
   _nextItemDeckOid = 1;
   firstPassItemSpawn = true;
+}
+
+std::vector<RaceTracker::RacerPositionInfo> RaceTracker::GetRacePositions() const
+{
+  std::vector<RacerPositionInfo> positions;
+  positions.reserve(_racers.size());
+
+  spdlog::debug("=== Race Positions Debug ===");
+  for (const auto& [characterUid, racer] : _racers) {
+    if (racer.state == Racer::State::Disconnected ||
+        racer.state == Racer::State::Finishing) {
+      continue;
+    }
+
+    spdlog::debug(
+      "Racer {}: trackProgress = {}, oid = {}",
+      characterUid,
+      racer.trackProgress,
+      racer.oid);
+    positions.push_back({
+      characterUid,
+      racer.trackProgress,
+      0,
+      racer.oid
+    });
+  }
+
+  // Sort by trackProgress DESCENDING (higher = better position, further ahead)
+  // Note: AcCmdUserRaceUpdatePos::member6 represents track progress where
+  // higher values = further ahead = better position (e.g., 1st: 0.3, 2nd: 0.2, 3rd: 0.1)
+  std::sort(positions.begin(), positions.end(), [](const auto& a, const auto& b) {
+      return a.trackProgress > b.trackProgress;
+  });
+
+  // Assign ranks (1-indexed)
+  for (size_t i = 0; i < positions.size(); ++i) {
+      positions[i].rank = static_cast<uint32_t>(i) + 1;
+      spdlog::debug("Rank {}: characterUid = {}, trackProgress = {}",
+          positions[i].rank, positions[i].characterUid, positions[i].trackProgress);
+  }
+  spdlog::debug("=== End Race Positions Debug ===");
+
+  return positions;
+}
+
+std::optional<RaceTracker::RacerPositionInfo> RaceTracker::GetRacerPosition(
+    data::Uid characterUid) const
+{
+  auto positions = GetRacePositions();
+
+  auto it = std::find_if(positions.begin(), positions.end(), [characterUid](const auto& p) {
+    return p.characterUid == characterUid;
+  });
+
+  if (it != positions.end()) {
+    return *it;
+  }
+  return std::nullopt;
 }
 
 } // namespace server::tracker


### PR DESCRIPTION
Aligns the server's magic item selection logic with the official database tables in `libconfig_c.dat` and resolves key allocation bugs.

Key Changes:
- Table Alignments:
  - Implemented separate solo group ratios (MagicGroupRatio) and team group ratios (MagicGroupTeamRatio)
  - Updated base slot probabilities to match Table 199 and Table 217 exactly
  - Added slot-level team modifiers (MagicSlotTeamModifier) for trailing assistance items
- Rank Normalization: Remaps player rank linearly onto the [1, 8] table columns to ensure last-place racers in small lobbies consistently scale to rank 8 weights

This implementation is far more comprehensive and extensive, using source of truth from `libconfig_c.dat` itself, in contrast to PR #271 which is a simple weights distribution implementation, based on community survey.