### PR TITLE
WIP: implement the achievement system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(alicia-libserver STATIC
         src/libserver/network/command/proto/RaceMessageDefinitions.cpp
         src/libserver/network/command/proto/RanchMessageDefinitions.cpp
         src/libserver/network/http/WebSocket.cpp
+        src/libserver/registry/AchievementRegistry.cpp
         src/libserver/registry/CharacterRegistry.cpp
         src/libserver/registry/CourseRegistry.cpp
         src/libserver/registry/BreedingRegistry.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(alicia-server
         src/server/ranch/Genetics.cpp
         src/server/ranch/RanchDirector.cpp
         src/server/room/Room.cpp
+        src/server/system/AchievementSystem.cpp
         src/server/system/ChatSystem.cpp
         src/server/system/HorseSystem.cpp
         src/server/system/InfractionSystem.cpp

--- a/include/libserver/data/DataDefinitions.hpp
+++ b/include/libserver/data/DataDefinitions.hpp
@@ -343,6 +343,28 @@ struct Character
 
   dao::Field<bool> isRanchLocked{};
 
+  //! The 3 ceremony achievement showcase slot TIDs.
+  //! Set via AcCmdCRSetKeyAchievement, displayed in personal info.
+  dao::Field<std::array<uint16_t, 3>> keyAchievements{};
+
+  //! Individual achievement completion data.
+  struct AchievementEntry
+  {
+    uint16_t tid{};
+    bool completed{};
+    uint32_t progress{};
+  };
+  dao::Field<std::vector<AchievementEntry>> achievements{};
+
+  //! Per-book achievement grade and tier progress.
+  struct AchievementBookEntry
+  {
+    uint8_t bookId{};
+    uint8_t grade{};
+    std::array<uint32_t, 4> tierProgress{};
+  };
+  dao::Field<std::vector<AchievementBookEntry>> achievementBooks{};
+
   dao::Field<Uid> settingsUid{InvalidUid};
 
   struct Skills

--- a/include/libserver/data/DataDefinitions.hpp
+++ b/include/libserver/data/DataDefinitions.hpp
@@ -343,25 +343,35 @@ struct Character
 
   dao::Field<bool> isRanchLocked{};
 
-  //! The 3 ceremony achievement showcase slot TIDs.
-  //! Set via AcCmdCRSetKeyAchievement, displayed in personal info.
+  //! The 3 key achievement TIDs, 0 for an empty slot. They need not be earned
+  //! and may repeat, which is how the client treats them.
   dao::Field<std::array<uint16_t, 3>> keyAchievements{};
 
   //! Individual achievement completion data.
   struct AchievementEntry
   {
+    //! Achievement TID. References libconfig `Achievements` table.
     uint16_t tid{};
-    bool completed{};
+    //! Accumulated progress towards the tier thresholds.
     uint32_t progress{};
+    //! The moment each of the four tiers was earned, the epoch while a tier is
+    //! not earned, so the count of set entries is the tier the player has
+    //! reached. Held as the absolute instant; the date the client displays is
+    //! derived from it when the page is built.
+    std::array<Clock::time_point, 4> tierEarnedAt{};
   };
   dao::Field<std::vector<AchievementEntry>> achievements{};
 
-  //! Per-book achievement grade and tier progress.
+  //! State of the four tier rewards of an achievement book. The grade of the
+  //! book is not stored, it follows from the achievements of that book.
   struct AchievementBookEntry
   {
+    //! Book type the entry belongs to, in an interval <0, 8>.
     uint8_t bookId{};
-    uint8_t grade{};
-    std::array<uint32_t, 4> tierProgress{};
+    //! Zero while the reward of that tier has not been collected. Only zero
+    //! versus non zero carries meaning, so what a collected entry holds beyond
+    //! that is open.
+    std::array<uint32_t, 4> tierRewardClaimed{};
   };
   dao::Field<std::vector<AchievementBookEntry>> achievementBooks{};
 

--- a/include/libserver/data/helper/ProtocolHelper.hpp
+++ b/include/libserver/data/helper/ProtocolHelper.hpp
@@ -18,6 +18,17 @@ namespace server
 namespace protocol
 {
 
+//! Packs a moment into the date format the achievement page expects, which is
+//! `year | (month << 12) | (day << 16)`. A year of zero is how the client marks
+//! a date as absent, so an unset moment packs to zero.
+//! The client builds this format from its own local time, so the conversion has
+//! to leave UTC here rather than in storage. It uses the time zone of the
+//! server, which is the closest the server gets without knowing the one of the
+//! player.
+//! @param timePoint The moment to pack.
+//! @returns The packed date, or zero when the moment is unset.
+uint32_t BuildProtocolAchievementDate(data::Clock::time_point timePoint);
+
 void BuildProtocolCharacter(
   Character& protocolCharacter,
   const data::Character& character);

--- a/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
+++ b/include/libserver/network/command/proto/CommonStructureDefinitions.hpp
@@ -556,14 +556,24 @@ struct RanchCharacter
 struct Quest
 {
   uint16_t tid{}; //questid
-  uint32_t member0{};          //maybe turnInNPC? used if the quest is ready to claim
+  //! Date of completion, packed as year | month << 12 in the low word and
+  //! day | hour << 5 | minute << 10 in the high word. The client only takes it
+  //! over when the status below is ReadyToClaim.
+  uint32_t completedAt{};
   enum Status : uint8_t{
     InProgress = 0,            // Quest started, objectives not yet met
     ReadyToClaim = 1,          // Objectives met, reward can be claimed
     Finished = 3               // Reward claimed / quest finished
   }status{};
   uint32_t progress{};         // used if the quest is in progress, otherwise unused
-  uint8_t member3{}; 
+  //! In the achievement list this is the tier index, counted from zero, and
+  //! 0xFF stands for no tier reached: the client sign-extends the byte and
+  //! treats -1 as "none". It selects which of the four per-tier slots the
+  //! progress above is stored in, and how many tiers get marked as earned.
+  //! Its meaning for quests is unknown, they leave it at zero.
+  uint8_t tier{};
+  //! The client parses this byte and never reads it again, on neither the
+  //! achievement nor the quest path. Its meaning is unknown.
   uint8_t member4{};
 
   static void Write(const Quest& value, SinkStream& stream);

--- a/include/libserver/network/command/proto/LobbyMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/LobbyMessageDefinitions.hpp
@@ -531,6 +531,10 @@ struct AcCmdCLAchievementCompleteList
     SourceStream& stream);
 };
 
+//! Count of achievement books the client accepts. It rejects the whole command
+//! when the list is longer, leaving the achievements page empty.
+constexpr size_t MaxAchievementBooks = 9;
+
 //! Clientbound achievement complete list response.
 //! Contains individual achievement progress AND per-book grade data.
 struct AcCmdCLAchievementCompleteListOK
@@ -541,13 +545,21 @@ struct AcCmdCLAchievementCompleteListOK
   //! Per-book achievement data. Drives the achievements page display.
   struct BookEntry
   {
-    //! Book/category ID (0-8). References libconfig `AchievementBook` table.
+    //! Book index in an interval <0, 8>.
     uint8_t bookId{};
-    //! Current grade/tier for this book.
+    //! Grade of the book, Bronze to Platinum in an interval <0, 3>. The client
+    //! takes it as given and indexes its four grade icons with it without
+    //! checking the bound, so anything outside the interval leaves the book
+    //! without an icon. There is no value standing for "no grade".
     uint8_t grade{};
-    //! Per-tier progress data (one per tier: Bronze/Silver/Gold/Platinum).
-    std::array<uint32_t, 4> tierProgress{};
+    //! Zero while the reward of that tier has not been collected. Only zero
+    //! versus non zero carries meaning. It is a precondition of the claim
+    //! button, not the whole of it: the client also requires every achievement
+    //! of the book to have reached the tier.
+    std::array<uint32_t, 4> tierRewardClaimed{};
   };
+  //! At most MaxAchievementBooks entries. The client drops the whole command
+  //! when there are more.
   std::vector<BookEntry> books{};
 
   static Command GetCommand()
@@ -1827,8 +1839,9 @@ struct AcCmdLCPersonalInfo
     float completionRate{};
     float member12{};
     uint32_t highestCarnivalPrize{};
-    //! Ceremony achievement showcase slot TIDs.
-    //! Set via AcCmdCRSetKeyAchievement, displayed on the profile.
+    //! The 3 key achievement TIDs, 0 for an empty slot. Set via
+    //! AcCmdCRSetKeyAchievement, shown as name and emblem on the challenge page
+    //! without any progress or tier of their own.
     std::array<uint16_t, 3> keyAchievements{};
     std::string introduction{};
     uint32_t level{0};

--- a/include/libserver/network/command/proto/LobbyMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/LobbyMessageDefinitions.hpp
@@ -532,10 +532,23 @@ struct AcCmdCLAchievementCompleteList
 };
 
 //! Clientbound achievement complete list response.
+//! Contains individual achievement progress AND per-book grade data.
 struct AcCmdCLAchievementCompleteListOK
 {
-  uint32_t unk0{};
-  std::vector<Quest> achievements;
+  uint32_t characterUid{};
+  std::vector<Quest> achievements{};
+
+  //! Per-book achievement data. Drives the achievements page display.
+  struct BookEntry
+  {
+    //! Book/category ID (0-8). References libconfig `AchievementBook` table.
+    uint8_t bookId{};
+    //! Current grade/tier for this book.
+    uint8_t grade{};
+    //! Per-tier progress data (one per tier: Bronze/Silver/Gold/Platinum).
+    std::array<uint32_t, 4> tierProgress{};
+  };
+  std::vector<BookEntry> books{};
 
   static Command GetCommand()
   {
@@ -1814,9 +1827,9 @@ struct AcCmdLCPersonalInfo
     float completionRate{};
     float member12{};
     uint32_t highestCarnivalPrize{};
-    uint16_t member14{};
-    uint16_t member15{};
-    uint16_t member16{};
+    //! Ceremony achievement showcase slot TIDs.
+    //! Set via AcCmdCRSetKeyAchievement, displayed on the profile.
+    std::array<uint16_t, 3> keyAchievements{};
     std::string introduction{};
     uint32_t level{0};
     //! Level progress as dictated by LevelInfo table in libconfig

--- a/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RaceMessageDefinitions.hpp
@@ -1012,11 +1012,16 @@ struct AcCmdRCRaceResultNotify
     uint32_t member6{};
     uint32_t carrots{};
     uint32_t level{};
-    // this is copied as memcpy
+    //! Team the racer rode for, two for red and three for blue. The client
+    //! pairs it with the points below to work out which team won.
     TeamColor teamColor{};
     uint32_t member10{};
     uint16_t member11{};
-    uint16_t member12{};
+    //! Points of this racer. The client adds them up per team and shows the
+    //! team with the higher sum as the winner, falling back to the team of the
+    //! first racer in this list when the sums are equal. The server leaves the
+    //! points at zero, so today that fallback decides every team race.
+    uint16_t points{};
     //! Time in milliseconds.
     uint32_t recordTimeDifference{};
     uint32_t levelProgress{};

--- a/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
@@ -1292,10 +1292,15 @@ struct AcCmdCRBreedingAbandonCancel
 
 struct AcCmdCRAchievementUpdateProperty
 {
-  //! 75 - level up
-  //! Table `Achievements`
+  //! Selects the tracked property, matching `UserAchvEvent` of the tables
+  //! `Achievements` and `AchvEventPropertyLink`, which names it. 26 is the
+  //! sliding count, 38 the top speed and 75 the NPC dialog level.
   uint16_t achievementEvent{};
-  uint16_t member2{};
+  //! The value the client reports for that property, carried as decimal text
+  //! rather than as a number: the client formats it with "%d" into a buffer of
+  //! 17 bytes, so at most 16 digits plus the terminator.
+  //! Whether this is the new absolute value or an increment is not established.
+  std::string propertyValue{};
 
   static Command GetCommand()
   {
@@ -5742,9 +5747,11 @@ struct AcCmdCRAchievementDetailOK
   //! The achievement TID.
   uint16_t achievementTid{};
 
-  //! Per-tier detail data. One value per tier:
-  //! [0] = Bronze, [1] = Silver, [2] = Gold, [3] = Platinum.
-  std::array<uint32_t, 4> tierProgress{};
+  //! The date each tier was earned on, [0] Bronze to [3] Platinum.
+  //! Packed as `year | (month << 12) | (day << 16)`.
+  //! A year of zero marks the tier as not earned, the client then shows a
+  //! placeholder instead of a date.
+  std::array<uint32_t, 4> tierEarnedDates{};
 
   static Command GetCommand()
   {
@@ -5783,12 +5790,95 @@ struct AcCmdCRAchievementDetailCancel
     SourceStream& stream);
 };
 
-//! Serverbound set key (ceremony/showcase) achievements.
-//! Sets the 3 achievement showcase slots displayed on the player's profile.
+//! Serverbound achievement book reward claim.
+//! Sent when the player confirms the gift dialog of a book.
+struct AcCmdCRAchievementBookReward
+{
+  //! Book type the reward is claimed for, in an interval <0, 8>.
+  int8_t bookType{};
+  //! Grade the reward is claimed for, in an interval <0, 3>.
+  int8_t grade{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRAchievementBookReward;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdCRAchievementBookReward& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdCRAchievementBookReward& command,
+    SourceStream& stream);
+};
+
+//! Clientbound achievement book reward claim acknowledgement.
+//! The client creates the item from this command and marks the grade as
+//! claimed on its own, it does not request the list again.
+struct AcCmdCRAchievementBookRewardOK
+{
+  //! Book type the reward was claimed for.
+  int8_t bookType{};
+  //! Grade the reward was claimed for.
+  int8_t grade{};
+  //! The granted item. A uid of zero means no item was created. Which of the
+  //! trailing fields matters depends on the item: the expiry applies to
+  //! equipment, the count to everything else. The client reads the count as 16
+  //! bits, so an amount above 65535 would arrive truncated.
+  Item item{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRAchievementBookRewardOK;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdCRAchievementBookRewardOK& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdCRAchievementBookRewardOK& command,
+    SourceStream& stream);
+};
+
+//! Clientbound achievement book reward claim rejection. Carries no fields.
+struct AcCmdCRAchievementBookRewardCancel
+{
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRAchievementBookRewardCancel;
+  }
+
+  static void Write(
+    const AcCmdCRAchievementBookRewardCancel& command,
+    SinkStream& stream);
+
+  static void Read(
+    AcCmdCRAchievementBookRewardCancel& command,
+    SourceStream& stream);
+};
+
+//! Serverbound set key achievements.
+//! Sets the 3 achievement slots shown on the challenge page and the profile.
+//! Sent in full whenever a slot is added, removed or moved.
 struct AcCmdCRSetKeyAchievement
 {
-  //! The 3 achievement TIDs for the ceremony showcase slots.
-  //! A value of 0 means the slot is empty.
+  //! The 3 achievement TIDs, 0 for an empty slot. The client accepts any
+  //! achievement that exists, whether it has been earned or not, and it allows
+  //! the same one in several slots.
   std::array<uint16_t, 3> keyAchievements{};
 
   static Command GetCommand()

--- a/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
+++ b/include/libserver/network/command/proto/RanchMessageDefinitions.hpp
@@ -5701,6 +5701,150 @@ struct AcCmdCRBreedingWishlistDelOK
     SourceStream& stream);
 };
 
+//! Serverbound achievement detail request.
+//! Requests detailed per-tier progress for a specific achievement.
+struct AcCmdCRAchievementDetail
+{
+  //! The character UID whose achievement detail is requested.
+  uint32_t characterUid{};
+
+  //! The achievement TID to query.
+  //! References libconfig `Achievements` table.
+  uint16_t achievementTid{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRAchievementDetail;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdCRAchievementDetail& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdCRAchievementDetail& command,
+    SourceStream& stream);
+};
+
+//! Clientbound achievement detail response.
+//! Contains per-tier progress data for a specific achievement.
+struct AcCmdCRAchievementDetailOK
+{
+  //! The character UID (echoed from request).
+  uint32_t characterUid{};
+
+  //! The achievement TID.
+  uint16_t achievementTid{};
+
+  //! Per-tier detail data. One value per tier:
+  //! [0] = Bronze, [1] = Silver, [2] = Gold, [3] = Platinum.
+  std::array<uint32_t, 4> tierProgress{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRAchievementDetailOK;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdCRAchievementDetailOK& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdCRAchievementDetailOK& command,
+    SourceStream& stream);
+};
+
+//! Clientbound achievement detail cancel.
+struct AcCmdCRAchievementDetailCancel
+{
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRAchievementDetailCancel;
+  }
+
+  static void Write(
+    const AcCmdCRAchievementDetailCancel& command,
+    SinkStream& stream);
+
+  static void Read(
+    AcCmdCRAchievementDetailCancel& command,
+    SourceStream& stream);
+};
+
+//! Serverbound set key (ceremony/showcase) achievements.
+//! Sets the 3 achievement showcase slots displayed on the player's profile.
+struct AcCmdCRSetKeyAchievement
+{
+  //! The 3 achievement TIDs for the ceremony showcase slots.
+  //! A value of 0 means the slot is empty.
+  std::array<uint16_t, 3> keyAchievements{};
+
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRSetKeyAchievement;
+  }
+
+  //! Writes the command to a provided sink stream.
+  //! @param command Command.
+  //! @param stream Sink stream.
+  static void Write(
+    const AcCmdCRSetKeyAchievement& command,
+    SinkStream& stream);
+
+  //! Reader a command from a provided source stream.
+  //! @param command Command.
+  //! @param stream Source stream.
+  static void Read(
+    AcCmdCRSetKeyAchievement& command,
+    SourceStream& stream);
+};
+
+//! Clientbound set key achievement response (empty - acknowledgment only).
+struct AcCmdCRSetKeyAchievementOK
+{
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRSetKeyAchievementOK;
+  }
+
+  static void Write(
+    const AcCmdCRSetKeyAchievementOK& command,
+    SinkStream& stream);
+
+  static void Read(
+    AcCmdCRSetKeyAchievementOK& command,
+    SourceStream& stream);
+};
+
+//! Clientbound set key achievement cancel.
+struct AcCmdCRSetKeyAchievementCancel
+{
+  static Command GetCommand()
+  {
+    return Command::AcCmdCRSetKeyAchievementCancel;
+  }
+
+  static void Write(
+    const AcCmdCRSetKeyAchievementCancel& command,
+    SinkStream& stream);
+
+  static void Read(
+    AcCmdCRSetKeyAchievementCancel& command,
+    SourceStream& stream);
+};
+
 } // namespace server::protocol
 
 #endif // RANCH_MESSAGE_DEFINES_HPP

--- a/include/libserver/registry/AchievementRegistry.hpp
+++ b/include/libserver/registry/AchievementRegistry.hpp
@@ -1,0 +1,73 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2024 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef ACHIEVEMENTREGISTRY_HPP
+#define ACHIEVEMENTREGISTRY_HPP
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace server::registry
+{
+
+struct AchievementInfo
+{
+  //! Achievement TID. References libconfig `Achievements` table.
+  uint16_t tid{};
+  //! Event ID that triggers progress for this achievement.
+  uint16_t eventId{};
+  //! Condition function name. "TRUE" means any event with matching eventId counts.
+  std::string function{};
+  //! Progress threshold required for completion.
+  uint32_t successValue{};
+  //! Which achievement book this belongs to (1-8).
+  uint8_t bookType{};
+  //! Carrot reward on completion.
+  uint32_t reward{};
+  //! Achievement points awarded on completion.
+  uint32_t points{};
+};
+
+class AchievementRegistry
+{
+public:
+  AchievementRegistry();
+
+  void ReadConfig(const std::filesystem::path& configPath);
+
+  //! Get all achievements triggered by a given event ID.
+  [[nodiscard]] std::vector<const AchievementInfo*>
+  GetAchievementsByEvent(uint16_t eventId) const;
+
+  //! Get a specific achievement by TID.
+  [[nodiscard]] const AchievementInfo* GetAchievement(uint16_t tid) const;
+
+private:
+  //! All achievements keyed by TID.
+  std::unordered_map<uint16_t, AchievementInfo> _achievements;
+  //! Index: event ID -> list of achievement TIDs.
+  std::unordered_multimap<uint16_t, uint16_t> _eventToTids;
+};
+
+} // namespace server::registry
+
+#endif // ACHIEVEMENTREGISTRY_HPP

--- a/include/libserver/registry/AchievementRegistry.hpp
+++ b/include/libserver/registry/AchievementRegistry.hpp
@@ -20,8 +20,10 @@
 #ifndef ACHIEVEMENTREGISTRY_HPP
 #define ACHIEVEMENTREGISTRY_HPP
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -29,22 +31,157 @@
 namespace server::registry
 {
 
+//! Count of tiers an achievement can be earned at,
+//! bronze, silver, gold and platinum.
+constexpr size_t AchievementTierCount = 4;
+
+//! Count of book types the client renders, so the types 0 to 8. The books the
+//! libconfig table defines outside that range belong to no page row.
+constexpr size_t AchievementBookTypeCount = 9;
+
+//! Game modes an achievement can be restricted to, as a bit set. The client
+//! numbers the four normal modes in this order in its room dialog, and the
+//! quest table encodes the same modes, see Quest::GameModeFlag.
+enum class GameModeFlag : uint8_t
+{
+  SpeedSingle = 1 << 0,
+  SpeedTeam = 1 << 1,
+  MagicSingle = 1 << 2,
+  MagicTeam = 1 << 3,
+  Mission = 1 << 4,
+  SpeedAgainstComputer = 1 << 5,
+  MagicAgainstComputer = 1 << 6
+};
+
+//! Turns the way a race is set up into the bit the achievements are filtered
+//! by, so that callers do not have to know the bit order.
+//! @param isMagic Whether the race is a magic race rather than a speed one.
+//! @param isTeam Whether it is raced in teams.
+//! @param isMission Whether it is a mission, which is a mode of its own.
+//! @returns The matching bit.
+[[nodiscard]] GameModeFlag ToGameModeFlag(
+  bool isMagic,
+  bool isTeam,
+  bool isMission);
+
+//! How a newly reported progress value combines with the stored one. The client
+//! never reads this column, so the meanings are read off the shipped data: all
+//! but four achievements use Count, and those four are named after their rule.
+enum class CompareType : uint8_t
+{
+  //! Number of times the event happened.
+  Count = 0,
+  //! Best result, lower being better. Used by the single lap time.
+  Minimum = 1,
+  //! Best result, higher being better. Used by top speed and spur count.
+  Maximum = 2,
+  //! Running total. Used by the carrots spent on purchases.
+  Sum = 3
+};
+
+//! How the reported value turns into progress. Read from
+//! achievement-conditions.yaml, which explains where each reading comes from.
+enum class ConditionKind : uint8_t
+{
+  //! The reported value is the progress.
+  Direct,
+  //! The value has to reach a bar, and the progress counts how often it did.
+  AtLeast,
+  //! The value has to stay below a bar, counted the same way.
+  AtMost,
+  //! Nothing ever satisfies this condition.
+  Never
+};
+
 struct AchievementInfo
 {
   //! Achievement TID. References libconfig `Achievements` table.
   uint16_t tid{};
-  //! Event ID that triggers progress for this achievement.
-  uint16_t eventId{};
-  //! Condition function name. "TRUE" means any event with matching eventId counts.
+  //! Event whose value the condition measures, which is how an achievement is
+  //! found when a report arrives. Defaults to the triggering event; two are
+  //! measured by another one, named in achievement-conditions.yaml.
+  uint16_t measuredEventId{};
+  //! How the value turns into progress.
+  ConditionKind conditionKind{ConditionKind::Direct};
+  //! Value the measured quantity is held against, for a gated condition.
+  uint32_t conditionBar{};
+  //! Name of the condition the event has to satisfy, "TRUE" when the event
+  //! itself is the condition.
   std::string function{};
-  //! Progress threshold required for completion.
-  uint32_t successValue{};
-  //! Which achievement book this belongs to (1-8).
-  uint8_t bookType{};
-  //! Carrot reward on completion.
-  uint32_t reward{};
-  //! Achievement points awarded on completion.
-  uint32_t points{};
+  //! Parameter of the condition, zero when it takes none. Used by 22 of them.
+  uint32_t functionValue{};
+  //! Condition putting the progress back to zero, empty when it accumulates.
+  //! The 29 achievements carrying one ask for a run rather than a total.
+  std::string resetFunction{};
+  //! Event the reset is judged on. Zero means the achievement's own event.
+  uint16_t resetEventId{};
+  //! Game modes the achievement counts in, as a bit set, see GameModeFlag.
+  //! Zero means every mode counts.
+  uint8_t gameModeFlag{};
+  //! Smallest field the race must have, zero when the size does not matter.
+  uint8_t numPlayer{};
+  //! Progress threshold of each tier, rising except where less is better, see
+  //! IsLowerBetter. A zero marks the tier as unused by this achievement.
+  std::array<uint32_t, AchievementTierCount> successValues{};
+  //! Carrot reward granted when the tier of the same index is reached.
+  std::array<uint32_t, AchievementTierCount> rewards{};
+  //! How progress accumulates, see CompareType.
+  CompareType compareType{};
+  //! Achievement book this belongs to. 1 to 8 are shown in the UI, 0 is the
+  //! system only book, -1 the book of completed challenges that no achievement
+  //! uses, and -2 no book at all.
+  int8_t bookType{};
+
+  //! Whether the achievement counts in the given game mode.
+  //! @param mode The mode the race runs in.
+  //! @returns True when the mode counts, which it always does for an
+  //!          achievement that names no mode at all.
+  [[nodiscard]] bool CountsInMode(GameModeFlag mode) const;
+
+  //! Whether the condition holds a reported value against a bar instead of
+  //! taking the value as the progress.
+  //! @returns True for a gated condition.
+  [[nodiscard]] bool IsGated() const;
+
+  //! Whether a reported value satisfies a gated condition.
+  //! @param value The measured value.
+  //! @returns True when the value passes the bar.
+  [[nodiscard]] bool PassesBar(uint32_t value) const;
+
+  //! Whether a lower progress value is the better one, which is the case for
+  //! the single lap time achievement and shows in its falling thresholds.
+  //! @returns True when less is better.
+  [[nodiscard]] bool IsLowerBetter() const;
+
+  //! Returns the count of tiers reached with the given progress,
+  //! so zero when not even the first threshold is met.
+  //! @param progress The accumulated progress.
+  //! @returns The count of tiers reached, at most AchievementTierCount.
+  [[nodiscard]] uint8_t GetReachedTierCount(uint32_t progress) const;
+
+  //! Combines a stored progress with a newly reported one. Counts and totals
+  //! grow by what happened since the previous report, records keep the better
+  //! of the two values.
+  //! @param stored The value held so far, zero when there is none.
+  //! @param reported The value the client just reported.
+  //! @param lastReported The value reported before, zero when there is none.
+  //! @returns The value to store.
+  [[nodiscard]] uint32_t CombineProgress(
+    uint32_t stored,
+    uint32_t reported,
+    uint32_t lastReported) const;
+};
+
+//! Reward for completing a book at a grade. The shipped data grants exactly one
+//! item per grade and no money, which is why this carries item ids only.
+struct AchievementBookRewardInfo
+{
+  //! Book type the reward belongs to, in an interval <1, 8>.
+  int8_t bookType{};
+  //! Character model the reward is meant for, 10 for the boy, 20 for the girl.
+  uint8_t characterModelId{};
+  //! Item granted for the grade of the same index.
+  std::array<uint32_t, AchievementTierCount> itemTids{};
 };
 
 class AchievementRegistry
@@ -52,20 +189,61 @@ class AchievementRegistry
 public:
   AchievementRegistry();
 
+  //! Reads the generated achievement data.
+  //! @param configPath Path of achievements.yaml.
   void ReadConfig(const std::filesystem::path& configPath);
 
-  //! Get all achievements triggered by a given event ID.
-  [[nodiscard]] std::vector<const AchievementInfo*>
+  //! Reads the hand written reading of the conditions and applies it to the
+  //! achievements already loaded, so it has to run after ReadConfig.
+  //! @param configPath Path of achievement-conditions.yaml.
+  void ReadConditions(const std::filesystem::path& configPath);
+
+  //! Get all achievements measured by a given event. The lists are built once
+  //! when the configuration is read, since every progress report passes here.
+  //! @param eventId The event a report arrived for.
+  //! @returns The achievements of that event, empty when there are none.
+  [[nodiscard]] std::span<const AchievementInfo* const>
   GetAchievementsByEvent(uint16_t eventId) const;
 
   //! Get a specific achievement by TID.
   [[nodiscard]] const AchievementInfo* GetAchievement(uint16_t tid) const;
 
+  //! Get all achievements belonging to a book.
+  //! @param bookType The book type the achievements reference.
+  //! @returns The achievements of that book, empty when there are none.
+  [[nodiscard]] std::span<const AchievementInfo* const>
+  GetAchievementsByBook(int8_t bookType) const;
+
+  //! Factor a reported value has to be multiplied by to reach the unit its
+  //! thresholds use.
+  //! @param eventId The event the value was reported for.
+  //! @returns The factor, one when the value already arrives in the right unit.
+  [[nodiscard]] double GetReportedValueScale(uint16_t eventId) const;
+
+  //! Get the reward of a book for a character model.
+  //! @param bookType The book type.
+  //! @param characterModelId The character model, 10 or 20.
+  //! @returns The reward, or nullptr when the book grants none.
+  [[nodiscard]] const AchievementBookRewardInfo* GetBookReward(
+    int8_t bookType,
+    uint8_t characterModelId) const;
+
 private:
+  //! Rebuilds the event index from the measured event of each achievement.
+  void RebuildEventIndex();
+
   //! All achievements keyed by TID.
   std::unordered_map<uint16_t, AchievementInfo> _achievements;
-  //! Index: event ID -> list of achievement TIDs.
-  std::unordered_multimap<uint16_t, uint16_t> _eventToTids;
+  //! Achievements measured by an event, built once so the hot path allocates
+  //! nothing.
+  std::unordered_map<uint16_t, std::vector<const AchievementInfo*>> _byEvent;
+  //! Achievements of a book, likewise prebuilt.
+  std::unordered_map<int8_t, std::vector<const AchievementInfo*>> _byBook;
+  //! Factor per event for the values that do not arrive in the unit their
+  //! thresholds use.
+  std::unordered_map<uint16_t, double> _reportedValueScales;
+  //! The book rewards, keyed by book type and character model.
+  std::vector<AchievementBookRewardInfo> _bookRewards;
 };
 
 } // namespace server::registry

--- a/include/server/ServerInstance.hpp
+++ b/include/server/ServerInstance.hpp
@@ -43,6 +43,7 @@
 #include "server/telemetry/Telemetry.hpp"
 
 #include <libserver/data/DataDirector.hpp>
+#include <libserver/registry/AchievementRegistry.hpp>
 #include <libserver/registry/BreedingRegistry.hpp>
 #include <libserver/registry/CharacterRegistry.hpp>
 #include <libserver/registry/CourseRegistry.hpp>
@@ -105,6 +106,10 @@ public:
   //! Returns reference to the private chat director.
   //! @returns Reference to the private chat director.
   PrivateChatDirector& GetPrivateChatDirector();
+
+  //! Returns reference to the Achievement registry.
+  //! @returns Reference to the Achievement registry.
+  registry::AchievementRegistry& GetAchievementRegistry();
 
   //! Returns reference to the Character registry.
   //! @returns Reference to the Character registry.
@@ -285,6 +290,8 @@ private:
   //! A race director.
   RaceDirector _raceDirector;
 
+  //! A registry of achievements.
+  registry::AchievementRegistry _achievementRegistry;
   //! A registry of character level info.
   registry::CharacterRegistry _characterRegistry;
   //! A registry of courses.

--- a/include/server/ServerInstance.hpp
+++ b/include/server/ServerInstance.hpp
@@ -30,6 +30,7 @@
 #include "server/ranch/BreedingMarket.hpp"
 #include "server/ranch/Genetics.hpp"
 #include "server/ranch/RanchDirector.hpp"
+#include "server/system/AchievementSystem.hpp"
 #include "server/system/ChatSystem.hpp"
 #include "server/system/HorseSystem.hpp"
 #include "server/system/InfractionSystem.hpp"
@@ -187,6 +188,10 @@ public:
   //! @returns Reference to the reward system.
   RewardSystem& GetRewardSystem();
 
+  //! Returns reference to the achievement system.
+  //! @returns Reference to the achievement system.
+  AchievementSystem& GetAchievementSystem();
+
   //! Returns reference to the telemetry.
   //! @returns Reference to the telemetry.
   Telemetry& GetTelemetry();
@@ -331,6 +336,8 @@ private:
   MatchmakingSystem _matchmakingSystem;
   //! A reward system.
   RewardSystem _rewardSystem;
+  //! An achievement system.
+  AchievementSystem _achievementSystem;
 
   //! A thread for telemetry.
   std::thread _telemetryThread;

--- a/include/server/race/RaceNetworkHandler.hpp
+++ b/include/server/race/RaceNetworkHandler.hpp
@@ -399,6 +399,23 @@ private:
     ClientId clientId,
     const protocol::AcCmdCRGameCreateClientItem& command);
 
+  //! Handles the achievement progress the client reports during a race. The
+  //! ranch connection is closed for the duration of a race, so the reports
+  //! arrive here rather than at the ranch.
+  void HandleAchievementUpdateProperty(
+    ClientId clientId,
+    const protocol::AcCmdCRAchievementUpdateProperty& command);
+
+  //! Applies a finished race to the achievements that wait on the result. The
+  //! client reports none of them, so the server describes the race itself.
+  //! @param clientId ID of the racer's client.
+  //! @param raceInstance The race that just ended for them.
+  //! @param finished Whether they reached the goal rather than giving up.
+  void AwardRaceAchievements(
+    ClientId clientId,
+    RaceInstance& raceInstance,
+    bool finished);
+
   //! A scheduler instance.
   Scheduler _scheduler;
   //! A server instance.

--- a/include/server/ranch/RanchDirector.hpp
+++ b/include/server/ranch/RanchDirector.hpp
@@ -577,6 +577,10 @@ private:
     ClientId clientId,
     const protocol::AcCmdCRAchievementUpdateProperty& command);
 
+  void HandleAchievementBookReward(
+    ClientId clientId,
+    const protocol::AcCmdCRAchievementBookReward& command);
+
   void HandleSetKeyAchievement(
     ClientId clientId,
     const protocol::AcCmdCRSetKeyAchievement& command);

--- a/include/server/ranch/RanchDirector.hpp
+++ b/include/server/ranch/RanchDirector.hpp
@@ -569,6 +569,18 @@ private:
     ClientId clientId,
     const protocol::AcCmdCRPasswordAuth command);
 
+  void HandleAchievementDetail(
+    ClientId clientId,
+    const protocol::AcCmdCRAchievementDetail& command);
+
+  void HandleAchievementUpdateProperty(
+    ClientId clientId,
+    const protocol::AcCmdCRAchievementUpdateProperty& command);
+
+  void HandleSetKeyAchievement(
+    ClientId clientId,
+    const protocol::AcCmdCRSetKeyAchievement& command);
+
   //! Ranch clients can only invite characters in other ranches.
   void HandleInviteUser(
     ClientId clientId,

--- a/include/server/system/AchievementSystem.hpp
+++ b/include/server/system/AchievementSystem.hpp
@@ -1,0 +1,150 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2024 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef ACHIEVEMENTSYSTEM_HPP
+#define ACHIEVEMENTSYSTEM_HPP
+
+#include <libserver/data/DataDefinitions.hpp>
+#include <libserver/network/command/proto/RaceMessageDefinitions.hpp>
+#include <libserver/registry/AchievementRegistry.hpp>
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace server
+{
+
+class ServerInstance;
+
+//! System responsible for achievement progress and for the derived state of the
+//! achievement page. The client reports over whichever connection it holds, the
+//! ranch one or the race one, so both handlers feed into this one place.
+class AchievementSystem
+{
+public:
+  //! What a reported property did to a single achievement, so the caller can
+  //! notify the client over its own connection.
+  struct ProgressUpdate
+  {
+    //! Achievement the update belongs to.
+    uint16_t achievementTid{};
+    //! Progress after the update.
+    uint32_t progress{};
+    //! Whether this update reached a new tier.
+    bool reachedTier{};
+    //! Tier that was reached, only meaningful when one was.
+    uint8_t tier{};
+    //! Carrot balance after any reward was paid.
+    int32_t carrotBalance{};
+  };
+
+  //! What a finished race amounted to for one racer. The client reports none of
+  //! this, so the server describes the race itself.
+  struct RaceOutcome
+  {
+    //! Mode the race ran in, which decides whether an achievement counts.
+    registry::GameModeFlag mode{};
+    //! Count of racers, for the achievements that demand a minimum field.
+    uint8_t racerCount{};
+    //! Place the racer took, one for the winner. Zero when they gave up.
+    uint8_t placement{};
+    //! Whether the racer reached the goal rather than giving up.
+    bool finished{};
+    //! Hour of the local day the race ended in, for the time of day conditions.
+    uint8_t hourOfDay{};
+  };
+
+  explicit AchievementSystem(ServerInstance& serverInstance);
+
+  //! Turns an update into the notification the client expects, which both
+  //! handlers send over their own connection.
+  //! @param update What changed for one achievement.
+  //! @returns The notification to queue.
+  [[nodiscard]] static protocol::AcCmdRCAchievementUpdateNotify BuildUpdateNotify(
+    const ProgressUpdate& update);
+
+  //! Applies a finished race to the achievements that wait on the result.
+  //! @param characterUid The racer.
+  //! @param outcome What the race amounted to for them.
+  //! @returns One entry per achievement whose progress changed.
+  [[nodiscard]] std::vector<ProgressUpdate> ApplyRaceOutcome(
+    data::Uid characterUid,
+    const RaceOutcome& outcome);
+
+  //! Applies a property value the client reported for an event.
+  //! @param characterUid The character the report belongs to.
+  //! @param eventId The event the client reported.
+  //! @param propertyValue The reported value as the client sent it.
+  //! @returns One entry per achievement whose progress changed.
+  [[nodiscard]] std::vector<ProgressUpdate> ApplyReportedProperty(
+    data::Uid characterUid,
+    uint16_t eventId,
+    const std::string& propertyValue);
+
+  //! Ends the play session, breaking the runs that have to hold within one
+  //! login.
+  //! @param characterUid The character that left the game.
+  void ApplySessionEnd(data::Uid characterUid);
+
+  //! Forgets what a character reported, so the next report counts in full. Done
+  //! when a race starts and on logout.
+  //! @param characterUid The character that left or entered a race.
+  void ForgetReportedValues(data::Uid characterUid);
+
+  //! Count of tiers carrying a date and therefore earned, filled in order.
+  //! @param entry The achievement record.
+  //! @returns The count of earned tiers.
+  [[nodiscard]] static uint8_t GetEarnedTierCount(
+    const data::Character::AchievementEntry& entry);
+
+  //! Count of tiers every achievement of a book has reached.
+  //! @param character The character.
+  //! @param bookType The book type.
+  //! @returns A count in an interval <0, 4>, zero for an empty book.
+  [[nodiscard]] uint8_t GetBookCompletedTierCount(
+    const data::Character& character,
+    int8_t bookType) const;
+
+  //! Grade to report for a book, the index of the highest tier every
+  //! achievement of the book has reached.
+  //! @param character The character.
+  //! @param bookType The book type.
+  //! @returns A grade in an interval <0, 3>, bronze while none is earned.
+  [[nodiscard]] uint8_t GetBookGrade(
+    const data::Character& character,
+    int8_t bookType) const;
+
+private:
+  ServerInstance& _serverInstance;
+
+  //! Guards the reported values, which two network handlers reach from their
+  //! own threads.
+  std::mutex _reportedValuesMutex;
+  //! Last value each character reported per event, from which the difference to
+  //! the next one is the new progress. Outlives a single connection, which is
+  //! why it does not live in a client context.
+  std::unordered_map<data::Uid, std::unordered_map<uint16_t, uint32_t>>
+    _reportedValues;
+};
+
+} // namespace server
+
+#endif // ACHIEVEMENTSYSTEM_HPP

--- a/resources/config/game/achievement-conditions.yaml
+++ b/resources/config/game/achievement-conditions.yaml
@@ -1,0 +1,181 @@
+# How the condition of an achievement is read.
+#
+# This file is written by hand and is NOT generated, unlike achievements.yaml
+# next to it. The client loads none of the condition columns, so their meaning
+# is the server's to define, and for a handful of achievements the bar exists
+# only in the Korean description rather than in a column. Every entry here
+# therefore carries the description it was taken from.
+#
+# An achievement not listed here is a plain counter: the reported value is the
+# progress, which is what the thresholds count.
+#
+# kind:
+#   never    the condition can never be satisfied
+#   atLeast  the measured value has to reach the bar, and the thresholds count
+#            how often it did rather than the value itself
+#   atMost   the same, with the value having to stay below the bar
+#
+# bar:
+#   omitted  the bar is the functionValue of the achievement
+#   given    the bar only exists in the description, quoted as the reason
+#
+# measuredEvent:
+#   omitted  the achievement is measured by the event that triggers it
+#   given    the achievement is triggered by one event but measured by another.
+#            This is an inference, not a fact, and it is used for exactly two
+#            achievements where the trigger cannot deliver what the description
+#            asks for while another event carries a matching value that nothing
+#            else references. It is not a general rule.
+# Reported values that do not arrive in the unit their thresholds are written
+# in. The client never holds the two against each other, so the conversion is
+# ours, and it belongs here with the rest of what the client does not define.
+scales:
+
+  # The client measures the speed in metres per second, while the thresholds of
+  # 110 to 125 only make sense as kilometres per hour: the description of the
+  # achievement reads "reach a driving speed of #@succ# km/h", the client
+  # refuses to report the event below 22.22, which is exactly 80 kilometres per
+  # hour, and as metres per second the thresholds would be four times the
+  # fastest horse.
+  - event: 38
+    factor: 3.6
+
+# Thresholds that exist only in the description, with no SuccessValue column
+# carrying them. Without the entry the achievement counts as reached on the
+# first event, because no threshold at all means a single step is enough.
+#
+# The count is ours to define without contradicting the screen: every one of
+# these carries a SuccessType of zero, and the client then draws a plain earned
+# or not earned bar instead of showing a progress against a threshold.
+#
+# Only counts of races belong here. Where a number in a description is a time
+# ("2분 30초") or something counted within a single race, as Sliding20 and
+# UseSpur40 do, the achievement is earned once and needs no threshold.
+thresholds:
+
+  # "게임 플레이 판수 20회" twenty games played.
+  - tid: 10012
+    successValues: [20]
+
+  # "모드에 상관 없이 2회 연속 패배" two losses in a row, any mode.
+  - tid: 10004
+    successValues: [2]
+
+  # "[마법모드]개인전 풀방 3연속 1등하기" three magic wins in a row.
+  - tid: 10027
+    successValues: [3]
+
+  # "8인 풀방에서 #연속 1위" wins in a row in a full room of eight.
+  - tid: 10056
+    successValues: [5]
+  - tid: 10057
+    successValues: [10]
+  - tid: 10058
+    successValues: [20]
+  - tid: 10059
+    successValues: [30]
+
+  # "8인 풀방에서 #연속 팀전 승리" team wins in a row in a full room of eight.
+  - tid: 10062
+    successValues: [5]
+  - tid: 10063
+    successValues: [10]
+  - tid: 10064
+    successValues: [20]
+  - tid: 10065
+    successValues: [30]
+
+  # "연속해서 리타이어 #회 당했을 때" retiring several times in a row.
+  - tid: 10070
+    successValues: [3]
+  - tid: 10071
+    successValues: [5]
+
+  # "연속 완주하기 #" races finished in a row.
+  - tid: 10075
+    successValues: [50]
+  - tid: 10076
+    successValues: [100]
+
+  # "한 번 접속해서 연속 30게임 완주" thirty finished in a row within one login.
+  - tid: 10079
+    successValues: [30]
+
+  # "자신보다 낮은 레벨의 유저가 1위하는 경기 10번 플레이하기" ten races won by
+  # someone of a lower level.
+  - tid: 10111
+    successValues: [10]
+
+conditions:
+
+  # "시스템 도전과제 북 완료 방지 용도로 절대 달성 불가 과제"
+  # A task deliberately made unreachable so the system book never completes.
+  - function: "False"
+    kind: never
+
+  # Perfect jumps in a row. The trigger counts single jumps, the run length is
+  # what event 32 measures, and no achievement references that event directly.
+  - function: "MaxPerfectJumpCombo"
+    kind: atLeast
+    measuredEvent: 32
+    bars:
+      # "퍼펙트점프 연속 5회 성공" five perfect jumps in a row
+      - tid: 10066
+        bar: 5
+      # "퍼펙트점프 연속 10회 성공" ten perfect jumps in a row
+      - tid: 10067
+        bar: 10
+      # "퍼펙트 점프 #@func#연속 성공하기", the bar is in the column
+      - tid: 10229
+
+  # Holding a glide. The trigger counts glides, the duration is event 34.
+  # "[스피드모드]글라이딩 5초 동안 유지" hold a glide for five seconds
+  - function: "FloatInTheAir"
+    kind: atLeast
+    measuredEvent: 34
+    bars:
+      - tid: 10007
+        bar: 5
+
+  # "슬라이딩 2초 이상 유지하기" hold a slide for at least two seconds
+  - function: "MaxSlidingTime"
+    kind: atLeast
+    bars:
+      - tid: 10113
+        bar: 2
+
+  # "슬라이딩 #@func#초이상 유지", the same bar, taken from the column
+  - function: "SlidingTime"
+    kind: atLeast
+
+  # "폭주마법 사용중에 3명 앞지르기" overtake three while hot rodding
+  - function: "HotRoddingReversalCount"
+    kind: atLeast
+    bars:
+      - tid: 10123
+        bar: 3
+      # "폭주마법 사용중에 #@func#명 앞지르기", the bar is in the column
+      - tid: 10194
+
+  # "퍼펙트 박차 #@func#회 이상 연속 성공하기" a run of perfect spurs
+  - function: "PerfectSpurCombo"
+    kind: atLeast
+
+  # The dialog level a conversation has to reach, one achievement per level.
+  # Without the bar all five complete on the first conversation.
+  - function: "DialogLevelCheck"
+    kind: atLeast
+
+  # Finishing the balloon quest inside a time, so a lower value is the better
+  # one and the thresholds count how often it was managed.
+  - function: "BalloonLapTime"
+    kind: atMost
+    bars:
+      # "풍선 퀘스트를 50초 안에 완료하기" finish within fifty seconds
+      - tid: 10152
+        bar: 50
+      # "풍선 퀘스트를 30초 안에 완료하기" finish within thirty seconds
+      - tid: 10153
+        bar: 30
+      # 10233 is not listed: "#@succ#초 이내 풍선게임 성공하기" compares the
+      # lap time against the threshold itself, which is the plain Minimum rule.

--- a/resources/config/game/achievements.yaml
+++ b/resources/config/game/achievements.yaml
@@ -1,0 +1,570 @@
+achievements:
+  collection:
+    # BookType 1 - Consecutive Experience
+    - tid: 10155
+      eventId: 43
+      function: GlidingDistance
+      successValue: 1
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10156
+      eventId: 17
+      function: TRUE
+      successValue: 1
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10157
+      eventId: 27
+      function: GlidingSpur
+      successValue: 1
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10158
+      eventId: 3
+      function: BuyItem
+      successValue: 500
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10159
+      eventId: 28
+      function: PerfectStart
+      successValue: 1
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10160
+      eventId: 29
+      function: PerfectJump
+      successValue: 5
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10161
+      eventId: 2
+      function: GoalIn
+      successValue: 3
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10162
+      eventId: 2
+      function: GoalIn
+      successValue: 2
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10163
+      eventId: 2
+      function: GoalIn_8h_13h
+      successValue: 2
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10164
+      eventId: 2
+      function: GoalIn_16h_18h
+      successValue: 2
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10165
+      eventId: 2
+      function: GoalIn_19h_22h
+      successValue: 2
+      bookType: 1
+      reward: 400
+      points: 1
+    - tid: 10166
+      eventId: 68
+      function: TRUE
+      successValue: 1
+      bookType: 1
+      reward: 400
+      points: 1
+    # BookType 2 - Horse Experience
+    - tid: 10167
+      eventId: 51
+      function: TRUE
+      successValue: 3
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10168
+      eventId: 50
+      function: TRUE
+      successValue: 3
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10169
+      eventId: 52
+      function: TRUE
+      successValue: 3
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10170
+      eventId: 53
+      function: ForciblyFeeding
+      successValue: 3
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10171
+      eventId: 53
+      function: FavoriteFoodsFeeding
+      successValue: 3
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10172
+      eventId: 53
+      function: Stuffed
+      successValue: 3
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10173
+      eventId: 55
+      function: TRUE
+      successValue: 1
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10174
+      eventId: 69
+      function: TRUE
+      successValue: 1
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10175
+      eventId: 71
+      function: TRUE
+      successValue: 1
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10176
+      eventId: 49
+      function: PolishUp
+      successValue: 1
+      bookType: 2
+      reward: 400
+      points: 1
+    - tid: 10177
+      eventId: 54
+      function: TraningSuccess
+      successValue: 1
+      bookType: 2
+      reward: 400
+      points: 1
+    # BookType 3 - Breeding Experience
+    - tid: 10178
+      eventId: 10
+      function: TRUE
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10179
+      eventId: 11
+      function: TRUE
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10180
+      eventId: 12
+      function: TRUE
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10181
+      eventId: 13
+      function: TRUE
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10182
+      eventId: 11
+      function: PotentialCapacities
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10183
+      eventId: 11
+      function: BreedingSuccessCombo
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10184
+      eventId: 10
+      function: TRUE
+      successValue: 2
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10185
+      eventId: 14
+      function: MaleHorseCombo
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10186
+      eventId: 56
+      function: PotentialCapacitiesGrow
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    - tid: 10187
+      eventId: 11
+      function: GradeCompare
+      successValue: 1
+      bookType: 3
+      reward: 400
+      points: 1
+    # BookType 4 - Fun Experience
+    - tid: 10188
+      eventId: 2
+      function: GoalInRanking
+      successValue: 5
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10189
+      eventId: 42
+      function: UseAllMagic
+      successValue: 5
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10190
+      eventId: 24
+      function: Cliff
+      successValue: 1
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10191
+      eventId: 2
+      function: ReversalWinner
+      successValue: 5
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10192
+      eventId: 2
+      function: CarnivalSuccess
+      successValue: 5
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10193
+      eventId: 42
+      function: JumpParalysis
+      successValue: 5
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10194
+      eventId: 35
+      function: HotRoddingReversalCount
+      successValue: 3
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10195
+      eventId: 57
+      function: TRUE
+      successValue: 20
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10196
+      eventId: 58
+      function: TRUE
+      successValue: 20
+      bookType: 4
+      reward: 400
+      points: 1
+    - tid: 10197
+      eventId: 59
+      function: TRUE
+      successValue: 20
+      bookType: 4
+      reward: 400
+      points: 1
+    # BookType 5 - Unique Experience
+    - tid: 10198
+      eventId: 23
+      function: TRUE
+      successValue: 5
+      bookType: 5
+      reward: 400
+      points: 1
+    - tid: 10199
+      eventId: 2
+      function: TeamWinTheLast
+      successValue: 5
+      bookType: 5
+      reward: 400
+      points: 1
+    - tid: 10200
+      eventId: 72
+      function: TRUE
+      successValue: 1
+      bookType: 5
+      reward: 400
+      points: 1
+    - tid: 10201
+      eventId: 57
+      function: Spur3thGoalIn
+      successValue: 1
+      bookType: 5
+      reward: 400
+      points: 1
+    - tid: 10202
+      eventId: 60
+      function: TRUE
+      successValue: 1
+      bookType: 5
+      reward: 400
+      points: 1
+    - tid: 10203
+      eventId: 70
+      function: TRUE
+      successValue: 1
+      bookType: 5
+      reward: 400
+      points: 1
+    - tid: 10204
+      eventId: 11
+      function: PoorHorse
+      successValue: 1
+      bookType: 5
+      reward: 400
+      points: 1
+    - tid: 10205
+      eventId: 11
+      function: GoodHorse
+      successValue: 1
+      bookType: 5
+      reward: 400
+      points: 1
+    # BookType 6 - Thrilling Experience
+    - tid: 10207
+      eventId: 62
+      function: TRUE
+      successValue: 5
+      bookType: 6
+      reward: 400
+      points: 1
+    - tid: 10208
+      eventId: 42
+      function: CriticalFireballAttack
+      successValue: 5
+      bookType: 6
+      reward: 400
+      points: 1
+    - tid: 10209
+      eventId: 42
+      function: RevengeAttackWithFireball
+      successValue: 5
+      bookType: 6
+      reward: 400
+      points: 1
+    - tid: 10210
+      eventId: 42
+      function: ComboAttackSuccessWithFireball
+      successValue: 5
+      bookType: 6
+      reward: 400
+      points: 1
+    - tid: 10211
+      eventId: 42
+      function: ShieldEndAttackWithFireball
+      successValue: 5
+      bookType: 6
+      reward: 400
+      points: 1
+    - tid: 10212
+      eventId: 74
+      function: TRUE
+      successValue: 5
+      bookType: 6
+      reward: 400
+      points: 1
+    - tid: 10213
+      eventId: 2
+      function: Revenge
+      successValue: 3
+      bookType: 6
+      reward: 400
+      points: 1
+    - tid: 10214
+      eventId: 42
+      function: FireBallSuccess
+      successValue: 3
+      bookType: 6
+      reward: 400
+      points: 1
+    # BookType 7 - Victory Experience
+    - tid: 10216
+      eventId: 2
+      function: WinAI
+      successValue: 1
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10217
+      eventId: 2
+      function: WinAI
+      successValue: 1
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10218
+      eventId: 11
+      function: GoodChild
+      successValue: 1
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10219
+      eventId: 42
+      function: LastSpurtAttack
+      successValue: 5
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10220
+      eventId: 61
+      function: PerfectSpurMaster
+      successValue: 3
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10221
+      eventId: 54
+      function: TrainingCombo
+      successValue: 3
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10222
+      eventId: 2
+      function: TeamPerfectWinNew
+      successValue: 3
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10223
+      eventId: 61
+      function: PerfectSpurCombo
+      successValue: 3
+      bookType: 7
+      reward: 400
+      points: 1
+    - tid: 10224
+      eventId: 54
+      function: TrainingCritical
+      successValue: 3
+      bookType: 7
+      reward: 400
+      points: 1
+    # BookType 8 - Skill Experience
+    - tid: 10225
+      eventId: 2
+      function: Win
+      successValue: 1
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10226
+      eventId: 2
+      function: Win
+      successValue: 1
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10227
+      eventId: 2
+      function: TeamWin
+      successValue: 1
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10228
+      eventId: 2
+      function: TeamWin
+      successValue: 1
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10229
+      eventId: 29
+      function: MaxPerfectJumpCombo
+      successValue: 30
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10230
+      eventId: 33
+      function: SlidingTime
+      successValue: 20
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10231
+      eventId: 17
+      function: MaxSpurCount
+      successValue: 4
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10232
+      eventId: 38
+      function: GetMaxSpeed
+      successValue: 110
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10233
+      eventId: 46
+      function: BalloonLapTime
+      successValue: 31
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10234
+      eventId: 2
+      function: MaxWinStop
+      successValue: 3
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10235
+      eventId: 61
+      function: TRUE
+      successValue: 1
+      bookType: 8
+      reward: 400
+      points: 1
+    - tid: 10236
+      eventId: 2
+      function: MaxWinStop
+      successValue: 3
+      bookType: 8
+      reward: 400
+      points: 1

--- a/resources/config/game/achievements.yaml
+++ b/resources/config/game/achievements.yaml
@@ -1,570 +1,2831 @@
+# Generated from the Achievements, AchievementBook,
+# AchievementBookReward and AchievementBookRewardSub tables of the
+# client's libconfig_c.dat. Do not edit by hand, regenerate when the
+# client data changes.
+#
+# successValues holds the four tier thresholds and rewards the carrots
+# granted for reaching the tier of the same index. A threshold of zero
+# marks the tier as unused.
+#
+# function, functionValue, gameModeFlag, compareType and numPlayer are
+# the condition. The client loads none of them, so the server alone
+# decides whether an event counts for an achievement.
 achievements:
   collection:
-    # BookType 1 - Consecutive Experience
-    - tid: 10155
-      eventId: 43
-      function: GlidingDistance
-      successValue: 1
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10156
-      eventId: 17
-      function: TRUE
-      successValue: 1
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10157
-      eventId: 27
-      function: GlidingSpur
-      successValue: 1
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10158
-      eventId: 3
-      function: BuyItem
-      successValue: 500
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10159
-      eventId: 28
-      function: PerfectStart
-      successValue: 1
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10160
-      eventId: 29
-      function: PerfectJump
-      successValue: 5
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10161
-      eventId: 2
-      function: GoalIn
-      successValue: 3
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10162
-      eventId: 2
-      function: GoalIn
-      successValue: 2
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10163
-      eventId: 2
-      function: GoalIn_8h_13h
-      successValue: 2
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10164
-      eventId: 2
-      function: GoalIn_16h_18h
-      successValue: 2
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10165
-      eventId: 2
-      function: GoalIn_19h_22h
-      successValue: 2
-      bookType: 1
-      reward: 400
-      points: 1
-    - tid: 10166
-      eventId: 68
-      function: TRUE
-      successValue: 1
-      bookType: 1
-      reward: 400
-      points: 1
-    # BookType 2 - Horse Experience
-    - tid: 10167
-      eventId: 51
-      function: TRUE
-      successValue: 3
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10168
-      eventId: 50
-      function: TRUE
-      successValue: 3
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10169
-      eventId: 52
-      function: TRUE
-      successValue: 3
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10170
-      eventId: 53
-      function: ForciblyFeeding
-      successValue: 3
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10171
-      eventId: 53
-      function: FavoriteFoodsFeeding
-      successValue: 3
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10172
-      eventId: 53
-      function: Stuffed
-      successValue: 3
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10173
-      eventId: 55
-      function: TRUE
-      successValue: 1
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10174
-      eventId: 69
-      function: TRUE
-      successValue: 1
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10175
-      eventId: 71
-      function: TRUE
-      successValue: 1
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10176
-      eventId: 49
-      function: PolishUp
-      successValue: 1
-      bookType: 2
-      reward: 400
-      points: 1
-    - tid: 10177
-      eventId: 54
-      function: TraningSuccess
-      successValue: 1
-      bookType: 2
-      reward: 400
-      points: 1
-    # BookType 3 - Breeding Experience
-    - tid: 10178
-      eventId: 10
-      function: TRUE
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10179
-      eventId: 11
-      function: TRUE
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10180
-      eventId: 12
-      function: TRUE
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10181
-      eventId: 13
-      function: TRUE
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10182
-      eventId: 11
-      function: PotentialCapacities
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10183
-      eventId: 11
-      function: BreedingSuccessCombo
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10184
-      eventId: 10
-      function: TRUE
-      successValue: 2
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10185
-      eventId: 14
-      function: MaleHorseCombo
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10186
-      eventId: 56
-      function: PotentialCapacitiesGrow
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    - tid: 10187
-      eventId: 11
-      function: GradeCompare
-      successValue: 1
-      bookType: 3
-      reward: 400
-      points: 1
-    # BookType 4 - Fun Experience
-    - tid: 10188
-      eventId: 2
-      function: GoalInRanking
-      successValue: 5
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10189
-      eventId: 42
-      function: UseAllMagic
-      successValue: 5
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10190
-      eventId: 24
-      function: Cliff
-      successValue: 1
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10191
-      eventId: 2
-      function: ReversalWinner
-      successValue: 5
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10192
-      eventId: 2
-      function: CarnivalSuccess
-      successValue: 5
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10193
-      eventId: 42
-      function: JumpParalysis
-      successValue: 5
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10194
-      eventId: 35
-      function: HotRoddingReversalCount
-      successValue: 3
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10195
-      eventId: 57
-      function: TRUE
-      successValue: 20
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10196
-      eventId: 58
-      function: TRUE
-      successValue: 20
-      bookType: 4
-      reward: 400
-      points: 1
-    - tid: 10197
-      eventId: 59
-      function: TRUE
-      successValue: 20
-      bookType: 4
-      reward: 400
-      points: 1
-    # BookType 5 - Unique Experience
-    - tid: 10198
-      eventId: 23
-      function: TRUE
-      successValue: 5
-      bookType: 5
-      reward: 400
-      points: 1
-    - tid: 10199
-      eventId: 2
-      function: TeamWinTheLast
-      successValue: 5
-      bookType: 5
-      reward: 400
-      points: 1
-    - tid: 10200
-      eventId: 72
-      function: TRUE
-      successValue: 1
-      bookType: 5
-      reward: 400
-      points: 1
-    - tid: 10201
-      eventId: 57
-      function: Spur3thGoalIn
-      successValue: 1
-      bookType: 5
-      reward: 400
-      points: 1
-    - tid: 10202
-      eventId: 60
-      function: TRUE
-      successValue: 1
-      bookType: 5
-      reward: 400
-      points: 1
-    - tid: 10203
-      eventId: 70
-      function: TRUE
-      successValue: 1
-      bookType: 5
-      reward: 400
-      points: 1
-    - tid: 10204
-      eventId: 11
-      function: PoorHorse
-      successValue: 1
-      bookType: 5
-      reward: 400
-      points: 1
-    - tid: 10205
-      eventId: 11
-      function: GoodHorse
-      successValue: 1
-      bookType: 5
-      reward: 400
-      points: 1
-    # BookType 6 - Thrilling Experience
-    - tid: 10207
-      eventId: 62
-      function: TRUE
-      successValue: 5
-      bookType: 6
-      reward: 400
-      points: 1
-    - tid: 10208
-      eventId: 42
-      function: CriticalFireballAttack
-      successValue: 5
-      bookType: 6
-      reward: 400
-      points: 1
-    - tid: 10209
-      eventId: 42
-      function: RevengeAttackWithFireball
-      successValue: 5
-      bookType: 6
-      reward: 400
-      points: 1
-    - tid: 10210
-      eventId: 42
-      function: ComboAttackSuccessWithFireball
-      successValue: 5
-      bookType: 6
-      reward: 400
-      points: 1
-    - tid: 10211
-      eventId: 42
-      function: ShieldEndAttackWithFireball
-      successValue: 5
-      bookType: 6
-      reward: 400
-      points: 1
-    - tid: 10212
-      eventId: 74
-      function: TRUE
-      successValue: 5
-      bookType: 6
-      reward: 400
-      points: 1
-    - tid: 10213
-      eventId: 2
-      function: Revenge
-      successValue: 3
-      bookType: 6
-      reward: 400
-      points: 1
-    - tid: 10214
-      eventId: 42
-      function: FireBallSuccess
-      successValue: 3
-      bookType: 6
-      reward: 400
-      points: 1
-    # BookType 7 - Victory Experience
-    - tid: 10216
-      eventId: 2
-      function: WinAI
-      successValue: 1
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10217
-      eventId: 2
-      function: WinAI
-      successValue: 1
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10218
-      eventId: 11
-      function: GoodChild
-      successValue: 1
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10219
-      eventId: 42
-      function: LastSpurtAttack
-      successValue: 5
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10220
-      eventId: 61
-      function: PerfectSpurMaster
-      successValue: 3
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10221
-      eventId: 54
-      function: TrainingCombo
-      successValue: 3
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10222
-      eventId: 2
-      function: TeamPerfectWinNew
-      successValue: 3
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10223
-      eventId: 61
-      function: PerfectSpurCombo
-      successValue: 3
-      bookType: 7
-      reward: 400
-      points: 1
-    - tid: 10224
-      eventId: 54
-      function: TrainingCritical
-      successValue: 3
-      bookType: 7
-      reward: 400
-      points: 1
-    # BookType 8 - Skill Experience
-    - tid: 10225
-      eventId: 2
-      function: Win
-      successValue: 1
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10226
-      eventId: 2
-      function: Win
-      successValue: 1
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10227
-      eventId: 2
-      function: TeamWin
-      successValue: 1
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10228
-      eventId: 2
-      function: TeamWin
-      successValue: 1
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10229
-      eventId: 29
-      function: MaxPerfectJumpCombo
-      successValue: 30
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10230
-      eventId: 33
-      function: SlidingTime
-      successValue: 20
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10231
-      eventId: 17
-      function: MaxSpurCount
-      successValue: 4
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10232
-      eventId: 38
-      function: GetMaxSpeed
-      successValue: 110
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10233
-      eventId: 46
-      function: BalloonLapTime
-      successValue: 31
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10234
-      eventId: 2
-      function: MaxWinStop
-      successValue: 3
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10235
-      eventId: 61
-      function: TRUE
-      successValue: 1
-      bookType: 8
-      reward: 400
-      points: 1
-    - tid: 10236
-      eventId: 2
-      function: MaxWinStop
-      successValue: 3
-      bookType: 8
-      reward: 400
-      points: 1
+      # 모든 박차 사용
+      - tid: 10001
+        eventId: 17
+        function: "ConsumeSpur"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 성공적인 첫 점프
+      - tid: 10002
+        eventId: 18
+        function: "OneJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 감격의 첫 달리기 승리
+      - tid: 10003
+        eventId: 2
+        function: "MyFirstWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 계속된 패배의 아픔
+      - tid: 10004
+        eventId: 2
+        function: "PainOfLosses"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 리비안 마을 2:30
+      - tid: 10005
+        eventId: 2
+        function: "RiLand03Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 성공적인 첫 대쉬
+      - tid: 10006
+        eventId: 19
+        function: "LearnDash"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 저 멀리 상공을 향해
+      - tid: 10007
+        eventId: 25
+        function: "FloatInTheAir"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 완벽한 승리
+      - tid: 10008
+        eventId: 2
+        function: "PerfectWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 그랜토 협곡 2:40
+      - tid: 10009
+        eventId: 2
+        function: "RiFore02Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 울렌 숲 2:20
+      - tid: 10010
+        eventId: 2
+        function: "RiFore01Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 포베아 들판 01
+      - tid: 10011
+        eventId: 2
+        function: "land02Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 노련한 플레이어
+      - tid: 10012
+        eventId: 2
+        function: "Playing20Races"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 실력 입증
+      - tid: 10013
+        eventId: 2
+        function: "SerialWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 1
+        bookType: -2
+      # 붉은도르프상회 2:30
+      - tid: 10014
+        eventId: 2
+        function: "RiDorf04Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 저 멀리 상공을 향해
+      - tid: 10015
+        eventId: 0
+        function: "Gliding50M"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 포베아 들판 2:20
+      - tid: 10016
+        eventId: 2
+        function: "RiLand02Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 실프 언덕 2:10
+      - tid: 10017
+        eventId: 2
+        function: "RiLand04Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 스타토 목장 2:20
+      - tid: 10018
+        eventId: 2
+        function: "RiLand01Mastery"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: -2
+      # 슬라이딩이 뭔가요?
+      - tid: 10019
+        eventId: 2
+        function: "NoSlidingWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 슬라이딩 플레이
+      - tid: 10020
+        eventId: 2
+        function: "Sliding20"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 박차! 박차! 박차!
+      - tid: 10021
+        eventId: 2
+        function: "UseSpur40"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 말의 기본은 달리기!
+      - tid: 10022
+        eventId: 2
+        function: "NoJumpWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 환상의 팀원
+      - tid: 10023
+        eventId: 2
+        function: "TeamPerfectWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 1단 점프 마스터
+      - tid: 10024
+        eventId: 2
+        function: "Mission_Movejump01_01"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 16
+        numPlayer: 0
+        bookType: -2
+      # 2단 점프 마스터
+      - tid: 10025
+        eventId: 2
+        function: "Mission_Movejump01_02"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 16
+        numPlayer: 0
+        bookType: -2
+      # 글라이딩 마스터
+      - tid: 10026
+        eventId: 2
+        function: "Mission_Moveglide01_01"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 16
+        numPlayer: 0
+        bookType: -2
+      # 기사단 마법사
+      - tid: 10027
+        eventId: 2
+        function: "Magic_TripleWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 4
+        numPlayer: 0
+        bookType: -2
+      # 파괴의 지옥꽃 생성자
+      - tid: 10028
+        eventId: 21
+        function: "Magic_NiceFlower"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 아이스 스톰!
+      - tid: 10029
+        eventId: 22
+        function: "Magic_NiceRange"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 격추!
+      - tid: 10030
+        eventId: 22
+        function: "Magic_CutHotRodding"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 신나는 박차
+      - tid: 10032
+        eventId: 17
+        function: "OneSpur"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 두근두근 슬라이딩
+      - tid: 10033
+        eventId: 26
+        function: "OneSliding"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 상쾌한 글라이딩
+      - tid: 10034
+        eventId: 25
+        function: "OneGliding"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 첫 번째 1등으로 골인
+      - tid: 10035
+        eventId: 2
+        function: "GoalInRanking"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 아까운 리타이어
+      - tid: 10036
+        eventId: 2
+        function: "Retire"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 설레이는 구매
+      - tid: 10037
+        eventId: 3
+        function: "BuyItemCount"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 소중한 내 성장
+      - tid: 10038
+        eventId: 5
+        function: "Level"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 소중한 말 성장
+      - tid: 10039
+        eventId: 6
+        function: "HorseLevel"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 교배로 말 획득하기
+      - tid: 10040
+        eventId: 19
+        function: "BreedSuccessCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 첫 번째 축제 참가하기
+      - tid: 10041
+        eventId: 19
+        function: "FestivalJoinCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 첫 번째 쪽지보내기
+      - tid: 10042
+        eventId: 19
+        function: "MessageSend"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 처음으로 친구 만들기
+      - tid: 10043
+        eventId: 19
+        function: "FriendCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 친구와 함께 게임하기
+      - tid: 10044
+        eventId: 19
+        function: "InGameFriendsCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 기분 나쁜 경험
+      - tid: 10045
+        eventId: 16
+        function: "Kicked"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 길드에 가입하기
+      - tid: 10046
+        eventId: 19
+        function: "GuildJoin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 선물하기
+      - tid: 10047
+        eventId: 19
+        function: "GiftSendCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 첫 번째 리셋당하기
+      - tid: 10048
+        eventId: 19
+        function: "ResetCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 슈퍼맨이 된 듯한 경험
+      - tid: 10049
+        eventId: 27
+        function: "OneGlidingSpur"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 첫 번째 스크린샷 찍기
+      - tid: 10050
+        eventId: 19
+        function: "OneScreenShot"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 출발이 좋은 경험
+      - tid: 10051
+        eventId: 28
+        function: "PerfectStart"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 첫 번째 대쉬 풀 게이지 획득
+      - tid: 10052
+        eventId: 19
+        function: "DashFullGauge"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 따라 올테면 따라와 봐
+      - tid: 10053
+        eventId: 2
+        function: "OtherRetirePlayerCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 1
+        bookType: -2
+      # 애송이 탈출
+      - tid: 10054
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 5
+        numPlayer: 8
+        bookType: -2
+      # 위풍당당
+      - tid: 10055
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [3, 4, 5, 6]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 5
+        numPlayer: 8
+        bookType: -2
+        resetFunction: "Lose"
+        resetEventId: 2
+      # 파죽지세
+      - tid: 10056
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 1
+        bookType: -2
+        resetFunction: "NotWin"
+        resetEventId: 0
+      # 위풍당당
+      - tid: 10057
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 5
+        numPlayer: 8
+        bookType: -2
+        resetFunction: "NotWin"
+        resetEventId: 2
+      # 천하무적
+      - tid: 10058
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 1
+        bookType: -2
+        resetFunction: "NotWin"
+        resetEventId: 0
+      # 내가 바로 NO.1
+      - tid: 10059
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 1
+        bookType: -2
+        resetFunction: "NotWin"
+        resetEventId: 0
+      # 팀원 잘 만났네!?
+      - tid: 10060
+        eventId: 2
+        function: "TeamWin"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 8
+        bookType: -2
+      # 우리는 일심동체
+      - tid: 10061
+        eventId: 2
+        function: "TeamWin"
+        functionValue: 0
+        successValues: [3, 4, 5, 6]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 8
+        bookType: -2
+        resetFunction: "TeamLose"
+        resetEventId: 2
+      # 우리는 일심동체
+      - tid: 10062
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [100, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 8
+        bookType: -2
+        resetFunction: "NotTeamWin"
+        resetEventId: 2
+      # 환상의 팀워크
+      - tid: 10063
+        eventId: 2
+        function: "TeamWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 1
+        bookType: -2
+        resetFunction: "NotTeamWin"
+        resetEventId: 0
+      # 누구든 와라
+      - tid: 10064
+        eventId: 2
+        function: "TeamWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 1
+        bookType: -2
+        resetFunction: "NotTeamWin"
+        resetEventId: 0
+      # 전설의 팀
+      - tid: 10065
+        eventId: 2
+        function: "TeamWin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 1
+        bookType: -2
+        resetFunction: "NotTeamWin"
+        resetEventId: 0
+      # 점프의 달인
+      - tid: 10066
+        eventId: 29
+        function: "MaxPerfectJumpCombo"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 점프의 대가
+      - tid: 10067
+        eventId: 29
+        function: "MaxPerfectJumpCombo"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 점프 매니아
+      - tid: 10068
+        eventId: 18
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "NotPerfectJump"
+        resetEventId: 0
+      # 점프 마스터
+      - tid: 10069
+        eventId: 18
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "NotPerfectJump"
+        resetEventId: 0
+      # 힘내세요
+      - tid: 10070
+        eventId: 2
+        function: "Retire"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "GoalIn"
+        resetEventId: 0
+      # 눈물 나는구먼
+      - tid: 10071
+        eventId: 2
+        function: "Retire"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "GoalIn"
+        resetEventId: 0
+      # 수고합니다
+      - tid: 10072
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [3, 4, 5, 6]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "Retire"
+        resetEventId: 2
+      # 훌륭합니다
+      - tid: 10073
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [5, 6, 7, 8]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "Retire"
+        resetEventId: 2
+      # 대단합니다
+      - tid: 10074
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [7, 8, 9, 10]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "Retire"
+        resetEventId: 2
+      # 놀랍습니다
+      - tid: 10075
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "Retire"
+        resetEventId: 0
+      # 그냥 재미있어서 했을 뿐..!!
+      - tid: 10076
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "Retire"
+        resetEventId: 0
+      # 손을 뗄 수가 없어
+      - tid: 10077
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [10, 11, 12, 13]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "TRUE"
+        resetEventId: 4
+      # 황홀경
+      - tid: 10078
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [20, 21, 22, 23]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "TRUE"
+        resetEventId: 4
+      # 무아지경
+      - tid: 10079
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "RetireOrDisconnect"
+        resetEventId: 0
+      # 퍼펙트 점프 1000번 달성
+      - tid: 10080
+        eventId: 18
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 퍼펙트 점프 2000번 달성
+      - tid: 10081
+        eventId: 18
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 퍼펙트 점프 3000번 달성
+      - tid: 10082
+        eventId: 18
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 퍼펙트 점프 4000번 달성
+      - tid: 10083
+        eventId: 18
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 퍼펙트 점프 5000번 달성
+      - tid: 10084
+        eventId: 18
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 이제는 나도 성인
+      - tid: 10085
+        eventId: 19
+        function: "BreedTry"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 첫사랑
+      - tid: 10086
+        eventId: 19
+        function: "BreedSuccess"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 시련의 아픔
+      - tid: 10087
+        eventId: 19
+        function: "BreedFail"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 풋내기 사랑
+      - tid: 10088
+        eventId: 0
+        function: "BreedTry"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 이것이 사랑..?
+      - tid: 10089
+        eventId: 0
+        function: "BreedTry"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 사랑에 못마른 그대
+      - tid: 10090
+        eventId: 0
+        function: "BreedTry"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 살랑은 언제나 목마르다
+      - tid: 10091
+        eventId: 0
+        function: "BreedTry"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 인생의 쓴맛
+      - tid: 10092
+        eventId: 0
+        function: "BreedFail"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 사랑! 두려움?
+      - tid: 10093
+        eventId: 0
+        function: "BreedFail"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 이 한몸 받쳐
+      - tid: 10094
+        eventId: 0
+        function: "BreedRegister"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 나는야 인기 스타
+      - tid: 10095
+        eventId: 0
+        function: "BreedHorse"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "BreedOtherHorse"
+        resetEventId: 0
+      # 나는야 기러기
+      - tid: 10096
+        eventId: 0
+        function: "BreedHorse"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "BreedOtherHorse"
+        resetEventId: 0
+      # 내 종자는 우수해
+      - tid: 10097
+        eventId: 0
+        function: "BreedSuccess"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "BreedFail"
+        resetEventId: 0
+      # 사랑에 집착하는 그대
+      - tid: 10098
+        eventId: 0
+        function: "BreedSuccess"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+        resetFunction: "BreedFail"
+        resetEventId: 0
+      # 내 자식은 영재
+      - tid: 10099
+        eventId: 0
+        function: "ChildGrade10_15"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 내 자식은 천재
+      - tid: 10100
+        eventId: 0
+        function: "ChildGrade16over"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 운수대통
+      - tid: 10101
+        eventId: 0
+        function: "FestivalReward"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 나는야 백만장자
+      - tid: 10102
+        eventId: 0
+        function: "FestivalReward"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 한탕주의자
+      - tid: 10103
+        eventId: 0
+        function: "FestivalReward"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 축제 매니아
+      - tid: 10104
+        eventId: 0
+        function: "FestivalJoin"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 7명의 친구와 함께 플레이하기
+      - tid: 10105
+        eventId: 0
+        function: "InGameFriendsCount"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 노블리스 오블리제
+      - tid: 10106
+        eventId: 19
+        function: "SlipStreamMinorSupplyTime"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 양보의 미덕
+      - tid: 10107
+        eventId: 2
+        function: "NoSpurRanking"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 언터처블
+      - tid: 10108
+        eventId: 2
+        function: "NoPlayerCollisionRanking"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 동물애호가
+      - tid: 10109
+        eventId: 2
+        function: "NoNPCCollision"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 너만은 밀어준다
+      - tid: 10110
+        eventId: 19
+        function: "CollisionPush"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 꼴찌들의 왕
+      - tid: 10111
+        eventId: 2
+        function: "KingOfLosers"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 그럼에도 불구하고
+      - tid: 10112
+        eventId: 2
+        function: "NoJumpRanking"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 그러다 넘어질라
+      - tid: 10113
+        eventId: 33
+        function: "MaxSlidingTime"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 처음부터 끝까지 1등으로 경기 끝내기
+      - tid: 10114
+        eventId: 2
+        function: "StartingWinner"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 10초이상 글라이딩 유지하기
+      - tid: 10115
+        eventId: 0
+        function: "GlidingTime"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 한번도 충돌하지 않고 완주하기
+      - tid: 10116
+        eventId: 2
+        function: "NoCollisionGoalIn"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 한번도 점프하지 않고 완주하기
+      - tid: 10117
+        eventId: 2
+        function: "NoJumpGoalIn"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 포기하지마
+      - tid: 10118
+        eventId: 2
+        function: "GoalInRanking"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 8
+        bookType: -2
+      # 레벨 10 달성하기
+      - tid: 10119
+        eventId: 5
+        function: "Level"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 말 최대 레벨까지 성장시키기
+      - tid: 10120
+        eventId: 5
+        function: "HorseLevel"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 나는야 부자
+      - tid: 10121
+        eventId: 0
+        function: "Money"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 지름신 강림
+      - tid: 10122
+        eventId: 0
+        function: "BuyMoneyTotal"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 한 때는 폭주족
+      - tid: 10123
+        eventId: 35
+        function: "HotRoddingReversalCount"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 카메라 마법으로 상대방 리셋시키기
+      - tid: 10124
+        eventId: 0
+        function: "TwistCauseReset"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 글라이딩 중인 상대에게 공격마법 성공시키기
+      - tid: 10125
+        eventId: 0
+        function: "MagicCauseFalling"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 말 체력을 완전히 소진시키기
+      - tid: 10126
+        eventId: 0
+        function: "HorseKnockdown"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 다른 사람과 같은 말이름 짓기
+      - tid: 10127
+        eventId: 0
+        function: "HorseSameName"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 공격한 상대에게 복수하기
+      - tid: 10128
+        eventId: 0
+        function: "MagicRevenge"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 관리스킬 5레벨 달성하기
+      - tid: 10129
+        eventId: 0
+        function: "TakecareLevel"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 나는야 마법사
+      - tid: 10130
+        eventId: 42
+        function: "UseAllMagic"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: -2
+      # 포토제닉1
+      - tid: 10131
+        eventId: 2
+        function: "GoalInWithSpur"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 포토제닉2
+      - tid: 10132
+        eventId: 2
+        function: "GoalInWithSliding"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 포토제닉3
+      - tid: 10133
+        eventId: 2
+        function: "GoalInWithGliding"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 정복자
+      - tid: 10134
+        eventId: 2
+        function: "GoalInAllMap"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 세계 제패
+      - tid: 10135
+        eventId: 2
+        function: "WinAllMap"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 거침없는 질주
+      - tid: 10136
+        eventId: 17
+        function: "MaxVelocity"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 초광속 폭주
+      - tid: 10137
+        eventId: 0
+        function: "MaxVelocity"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 속도의 중독자
+      - tid: 10138
+        eventId: 0
+        function: "MaxVelocity"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 폭주 기관차
+      - tid: 10139
+        eventId: 2
+        function: "ReversalWinner"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 4단 박차 사용
+      - tid: 10140
+        eventId: 17
+        function: "SpurLevel"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 5단 박차 사용
+      - tid: 10141
+        eventId: 17
+        function: "SpurLevel"
+        functionValue: 0
+        successValues: [0, 0, 0, 0]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 아슬아슬 퍼펙트 점프
+      - tid: 10142
+        eventId: 29
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 점프의 깨달음1
+      - tid: 10143
+        eventId: 29
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [30, 31, 32, 33]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 점프의 깨달음2
+      - tid: 10144
+        eventId: 29
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [50, 51, 52, 53]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 3
+        numPlayer: 0
+        bookType: -2
+      # 한가하면 한 게임?
+      - tid: 10145
+        eventId: 2
+        function: "GoalIn_14h_16h"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 학교 끝나면 앨리샤지!
+      - tid: 10146
+        eventId: 2
+        function: "GoalIn_16h_18h"
+        functionValue: 0
+        successValues: [30, 31, 32, 33]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 저녁형 인간
+      - tid: 10147
+        eventId: 2
+        function: "GoalIn_19h_22h"
+        functionValue: 0
+        successValues: [30, 31, 32, 33]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: -2
+      # 첫 이름 지어주기
+      - tid: 10148
+        eventId: 47
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 기본 지식을 익히다
+      - tid: 10149
+        eventId: 45
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 방문하기
+      - tid: 10150
+        eventId: 48
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [10, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 풍선 터뜨리기 완료
+      - tid: 10151
+        eventId: 46
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [10, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 풍선 터뜨리기 재밌다!
+      - tid: 10152
+        eventId: 46
+        function: "BalloonLapTime"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [10, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 풍선 터뜨리기 달인
+      - tid: 10153
+        eventId: 46
+        function: "BalloonLapTime"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [10, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 말 관리 자격증 획득
+      - tid: 10154
+        eventId: 5
+        function: "Level"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: -2
+      # 상쾌한 글라이딩
+      - tid: 10155
+        eventId: 43
+        function: "GlidingDistance"
+        functionValue: 0
+        successValues: [1, 100, 500, 1800]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+      # 신나는 박차
+      - tid: 10156
+        eventId: 17
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 100, 2000, 6000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 1
+      # 슈퍼맨이 된 듯한 경험
+      - tid: 10157
+        eventId: 27
+        function: "GlidingSpur"
+        functionValue: 0
+        successValues: [1, 100, 200, 6000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 1
+      # 설레이는 구매
+      - tid: 10158
+        eventId: 3
+        function: "BuyItem"
+        functionValue: 0
+        successValues: [500, 10000, 50000, 200000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 3
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 1
+      # 출발이 좋은 경험
+      - tid: 10159
+        eventId: 28
+        function: "PerfectStart"
+        functionValue: 0
+        successValues: [1, 150, 300, 1500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+      # 점프의 깨달음
+      - tid: 10160
+        eventId: 29
+        function: "PerfectJump"
+        functionValue: 0
+        successValues: [5, 500, 2500, 10000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 1
+      # 수고합니다
+      - tid: 10161
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [3, 6, 10, 15]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+        resetFunction: "Retire"
+        resetEventId: 2
+      # 손을 뗄 수가 없어
+      - tid: 10162
+        eventId: 2
+        function: "GoalIn"
+        functionValue: 0
+        successValues: [2, 5, 10, 20]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+        resetFunction: "TRUE"
+        resetEventId: 4
+      # 아침형 인간
+      - tid: 10163
+        eventId: 2
+        function: "GoalIn_8h_13h"
+        functionValue: 0
+        successValues: [2, 20, 100, 500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+      # 학교 끝나면 앨리샤지!
+      - tid: 10164
+        eventId: 2
+        function: "GoalIn_16h_18h"
+        functionValue: 0
+        successValues: [2, 20, 100, 500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+      # 저녁형 인간
+      - tid: 10165
+        eventId: 2
+        function: "GoalIn_19h_22h"
+        functionValue: 0
+        successValues: [2, 20, 100, 500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+      # 숙련된 말
+      - tid: 10166
+        eventId: 68
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 2, 5, 15]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 1
+      # 갈기를 깨끗이
+      - tid: 10167
+        eventId: 51
+        function: "TRUE"
+        functionValue: 0
+        successValues: [3, 70, 500, 5000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 몸을 깨끗이
+      - tid: 10168
+        eventId: 50
+        function: "TRUE"
+        functionValue: 0
+        successValues: [3, 70, 500, 5000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 꼬리를 깨끗이
+      - tid: 10169
+        eventId: 52
+        function: "TRUE"
+        functionValue: 0
+        successValues: [3, 70, 500, 5000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 골고루 먹이기
+      - tid: 10170
+        eventId: 53
+        function: "ForciblyFeeding"
+        functionValue: 0
+        successValues: [3, 10, 30, 40]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 좋아하는 것만 먹이기
+      - tid: 10171
+        eventId: 53
+        function: "FavoriteFoodsFeeding"
+        functionValue: 0
+        successValues: [3, 50, 500, 10000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 든든하게 먹이기
+      - tid: 10172
+        eventId: 53
+        function: "Stuffed"
+        functionValue: 0
+        successValues: [3, 50, 300, 2000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 나중에 다시 만나자
+      - tid: 10173
+        eventId: 55
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 3, 5, 20]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 나 때문에 너가
+      - tid: 10174
+        eventId: 69
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 5, 30, 200]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: 2
+      # 경상쯤은! 자연치료!
+      - tid: 10175
+        eventId: 71
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 3, 5, 50]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 엘레강스한 자태
+      - tid: 10176
+        eventId: 49
+        function: "PolishUp"
+        functionValue: 0
+        successValues: [1, 10, 150, 1000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 나도 이제 조련사
+      - tid: 10177
+        eventId: 54
+        function: "TraningSuccess"
+        functionValue: 0
+        successValues: [1, 20, 300, 1000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 2
+      # 사랑에 목마른 그대
+      - tid: 10178
+        eventId: 10
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 5, 30, 100]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 연애박사
+      - tid: 10179
+        eventId: 11
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 5, 10, 50]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 인생의 쓴맛
+      - tid: 10180
+        eventId: 12
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 10, 30, 50]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 이 한 몸 바쳐
+      - tid: 10181
+        eventId: 13
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 10, 100, 250]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 잠재능력!
+      - tid: 10182
+        eventId: 11
+        function: "PotentialCapacities"
+        functionValue: 0
+        successValues: [1, 3, 5, 25]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 내 종자는 우수해
+      - tid: 10183
+        eventId: 11
+        function: "BreedingSuccessCombo"
+        functionValue: 2
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 사랑에 집착하는 그대
+      - tid: 10184
+        eventId: 10
+        function: "TRUE"
+        functionValue: 0
+        successValues: [2, 3, 4, 5]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+        resetFunction: "TRUE"
+        resetEventId: 8
+      # 너만을 믿는다
+      - tid: 10185
+        eventId: 14
+        function: "MaleHorseCombo"
+        functionValue: 3
+        successValues: [1, 3, 5, 8]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 이제 능력만 발휘하면 돼
+      - tid: 10186
+        eventId: 56
+        function: "PotentialCapacitiesGrow"
+        functionValue: 0
+        successValues: [1, 3, 5, 25]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 미운 오리새끼
+      - tid: 10187
+        eventId: 11
+        function: "GradeCompare"
+        functionValue: 0
+        successValues: [1, 3, 10, 50]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 3
+      # 포기하지마
+      - tid: 10188
+        eventId: 2
+        function: "GoalInRanking"
+        functionValue: 8
+        successValues: [5, 30, 150, 600]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 8
+        bookType: 4
+      # 나는야 마법사
+      - tid: 10189
+        eventId: 42
+        function: "UseAllMagic"
+        functionValue: 3
+        successValues: [5, 50, 500, 2000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 4
+      # 과속은 위험해
+      - tid: 10190
+        eventId: 24
+        function: "Cliff"
+        functionValue: 0
+        successValues: [1, 3, 5, 30]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 4
+      # 폭주 기관차
+      - tid: 10191
+        eventId: 2
+        function: "ReversalWinner"
+        functionValue: 0
+        successValues: [5, 50, 100, 500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 2
+        bookType: 4
+      # 두근두근 축제 경험
+      - tid: 10192
+        eventId: 2
+        function: "CarnivalSuccess"
+        functionValue: 0
+        successValues: [5, 30, 150, 400]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 31
+        numPlayer: 0
+        bookType: 4
+      # 작전 성공
+      - tid: 10193
+        eventId: 42
+        function: "JumpParalysis"
+        functionValue: 3
+        successValues: [5, 30, 150, 400]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 4
+      # 한 때는 폭주족
+      - tid: 10194
+        eventId: 35
+        function: "HotRoddingReversalCount"
+        functionValue: 3
+        successValues: [3, 10, 50, 150]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 4
+      # 포토제닉1
+      - tid: 10195
+        eventId: 57
+        function: "TRUE"
+        functionValue: 0
+        successValues: [20, 100, 300, 2000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 4
+      # 포토제닉2
+      - tid: 10196
+        eventId: 58
+        function: "TRUE"
+        functionValue: 0
+        successValues: [20, 100, 300, 2000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 4
+      # 포토제닉3
+      - tid: 10197
+        eventId: 59
+        function: "TRUE"
+        functionValue: 0
+        successValues: [20, 100, 300, 2000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 4
+      # 수사반장
+      - tid: 10198
+        eventId: 23
+        function: "TRUE"
+        functionValue: 0
+        successValues: [5, 20, 50, 500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 5
+      # 팀원 잘 만났네
+      - tid: 10199
+        eventId: 2
+        function: "TeamWinTheLast"
+        functionValue: 0
+        successValues: [5, 30, 100, 200]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 8
+        bookType: 5
+      # 어쩌다 보니
+      - tid: 10200
+        eventId: 72
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 100, 250, 500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 5
+      # 내 말은 추입마
+      - tid: 10201
+        eventId: 57
+        function: "Spur3thGoalIn"
+        functionValue: 0
+        successValues: [1, 50, 150, 300]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 5
+      # 폼생폼사
+      - tid: 10202
+        eventId: 60
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 300, 700, 1500]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 5
+      # 다치지마렴
+      - tid: 10203
+        eventId: 70
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 20, 50, 200]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 5
+      # 미숙마의 경험
+      - tid: 10204
+        eventId: 11
+        function: "PoorHorse"
+        functionValue: 400
+        successValues: [1, 2, 3, 5]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 5
+      # 우량마의 경험
+      - tid: 10205
+        eventId: 11
+        function: "GoodHorse"
+        functionValue: 500
+        successValues: [1, 2, 3, 5]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 5
+      # 이것 받으세요
+      - tid: 10207
+        eventId: 62
+        function: "TRUE"
+        functionValue: 0
+        successValues: [5, 30, 100, 800]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 6
+      # 그냥은 안 때려!
+      - tid: 10208
+        eventId: 42
+        function: "CriticalFireballAttack"
+        functionValue: 0
+        successValues: [5, 30, 200, 1000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 6
+      # 그냥은 안 보내!
+      - tid: 10209
+        eventId: 42
+        function: "RevengeAttackWithFireball"
+        functionValue: 0
+        successValues: [5, 10, 25, 70]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 12
+        numPlayer: 0
+        bookType: 6
+      # 너만을 노린다
+      - tid: 10210
+        eventId: 42
+        function: "ComboAttackSuccessWithFireball"
+        functionValue: 3
+        successValues: [5, 10, 25, 50]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 6
+      # 이때를 기다렸다
+      - tid: 10211
+        eventId: 42
+        function: "ShieldEndAttackWithFireball"
+        functionValue: 3
+        successValues: [5, 10, 25, 100]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 6
+      # 쾌감 절정
+      - tid: 10212
+        eventId: 74
+        function: "TRUE"
+        functionValue: 0
+        successValues: [5, 10, 25, 50]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 6
+      # 복수 혈전
+      - tid: 10213
+        eventId: 2
+        function: "Revenge"
+        functionValue: 0
+        successValues: [3, 10, 25, 50]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 15
+        numPlayer: 0
+        bookType: 6
+      # 그렇게는 안되지
+      - tid: 10214
+        eventId: 42
+        function: "FireBallSuccess"
+        functionValue: 0
+        successValues: [3, 15, 70, 400]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 6
+      # 견습기사단정도는 1
+      - tid: 10216
+        eventId: 2
+        function: "WinAI"
+        functionValue: 0
+        successValues: [1, 5, 10, 20]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 32
+        numPlayer: 0
+        bookType: 7
+      # 견습기사단정도는 2
+      - tid: 10217
+        eventId: 2
+        function: "WinAI"
+        functionValue: 0
+        successValues: [1, 5, 10, 20]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 64
+        numPlayer: 0
+        bookType: 7
+      # 운수대통
+      - tid: 10218
+        eventId: 11
+        function: "GoodChild"
+        functionValue: 0
+        successValues: [1, 2, 3, 4]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 7
+      # 고추가루
+      - tid: 10219
+        eventId: 42
+        function: "LastSpurtAttack"
+        functionValue: 0
+        successValues: [5, 30, 50, 300]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 76
+        numPlayer: 0
+        bookType: 7
+      # 어떤 상황에서도
+      - tid: 10220
+        eventId: 61
+        function: "PerfectSpurMaster"
+        functionValue: 0
+        successValues: [3, 50, 500, 2000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 7
+      # 타이밍의 마스터
+      - tid: 10221
+        eventId: 54
+        function: "TrainingCombo"
+        functionValue: 3
+        successValues: [3, 50, 200, 400]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 7
+      # 완벽하다
+      - tid: 10222
+        eventId: 2
+        function: "TeamPerfectWinNew"
+        functionValue: 0
+        successValues: [3, 20, 50, 150]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 4
+        bookType: 7
+      # 박차 마스터
+      - tid: 10223
+        eventId: 61
+        function: "PerfectSpurCombo"
+        functionValue: 3
+        successValues: [3, 100, 300, 1000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 7
+      # 운 좋은 날
+      - tid: 10224
+        eventId: 54
+        function: "TrainingCritical"
+        functionValue: 0
+        successValues: [3, 70, 300, 1000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 7
+      # 위풍당당
+      - tid: 10225
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [1, 10, 50, 100]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 1
+        numPlayer: 4
+        bookType: 8
+      # 천하무적
+      - tid: 10226
+        eventId: 2
+        function: "Win"
+        functionValue: 0
+        successValues: [1, 10, 50, 100]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 4
+        numPlayer: 4
+        bookType: 8
+      # 우리는 일심동체
+      - tid: 10227
+        eventId: 2
+        function: "TeamWin"
+        functionValue: 0
+        successValues: [1, 10, 50, 300]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 2
+        numPlayer: 4
+        bookType: 8
+      # 누구든 와라
+      - tid: 10228
+        eventId: 2
+        function: "TeamWin"
+        functionValue: 0
+        successValues: [1, 10, 50, 300]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 8
+        numPlayer: 4
+        bookType: 8
+      # 점프의 달인
+      - tid: 10229
+        eventId: 29
+        function: "MaxPerfectJumpCombo"
+        functionValue: 10
+        successValues: [30, 200, 500, 2000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 8
+      # 그러다 넘어질라
+      - tid: 10230
+        eventId: 33
+        function: "SlidingTime"
+        functionValue: 2
+        successValues: [20, 300, 700, 3000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 8
+      # 한계 돌파
+      - tid: 10231
+        eventId: 17
+        function: "MaxSpurCount"
+        functionValue: 3
+        successValues: [4, 5, 7, 10]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 2
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 8
+      # 거침없는 질주
+      - tid: 10232
+        eventId: 38
+        function: "GetMaxSpeed"
+        functionValue: 0
+        successValues: [110, 120, 123, 125]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 2
+        gameModeFlag: 127
+        numPlayer: 0
+        bookType: 8
+      # 풍선 매니아
+      - tid: 10233
+        eventId: 46
+        function: "BalloonLapTime"
+        functionValue: 0
+        successValues: [31, 30, 29, 28]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 1
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 8
+      # 할 만큼 했네?
+      - tid: 10234
+        eventId: 2
+        function: "MaxWinStop"
+        functionValue: 0
+        successValues: [3, 15, 30, 70]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 5
+        numPlayer: 0
+        bookType: 8
+      # 완벽주의자
+      - tid: 10235
+        eventId: 61
+        function: "TRUE"
+        functionValue: 0
+        successValues: [1, 100, 1000, 5000]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 35
+        numPlayer: 0
+        bookType: 8
+      # 최강팀 등극!
+      - tid: 10236
+        eventId: 2
+        function: "MaxWinStop"
+        functionValue: 0
+        successValues: [3, 15, 30, 70]
+        rewards: [400, 800, 1200, 2000]
+        compareType: 0
+        gameModeFlag: 10
+        numPlayer: 0
+        bookType: 8
+      # 첫 상점 진입
+      - tid: 20001
+        eventId: 65
+        function: "True"
+        functionValue: 0
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 첫 내 장비 진입
+      - tid: 20002
+        eventId: 66
+        function: "True"
+        functionValue: 0
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 첫 말 관리 진입
+      - tid: 20003
+        eventId: 67
+        function: "True"
+        functionValue: 0
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 첫 말 이름 짓기
+      - tid: 20004
+        eventId: 47
+        function: "True"
+        functionValue: 0
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 인트로 완료
+      - tid: 20005
+        eventId: 45
+        function: "True"
+        functionValue: 0
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 시스템 예약 항목
+      - tid: 20000
+        eventId: 45
+        function: "False"
+        functionValue: 0
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 레벨 2
+      - tid: 20006
+        eventId: 5
+        function: "LevelCheck"
+        functionValue: 2
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 레벨 3
+      - tid: 20007
+        eventId: 5
+        function: "LevelCheck"
+        functionValue: 3
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 레벨2 NPC 대화
+      - tid: 20008
+        eventId: 75
+        function: "DialogLevelCheck"
+        functionValue: 2
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 레벨5 NPC 대화
+      - tid: 20009
+        eventId: 75
+        function: "DialogLevelCheck"
+        functionValue: 5
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 레벨12 NPC 대화
+      - tid: 20010
+        eventId: 75
+        function: "DialogLevelCheck"
+        functionValue: 12
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 레벨8 NPC 대화
+      - tid: 20011
+        eventId: 75
+        function: "DialogLevelCheck"
+        functionValue: 8
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+      # 레벨10 NPC 대화
+      - tid: 20012
+        eventId: 75
+        function: "DialogLevelCheck"
+        functionValue: 10
+        successValues: [1, 1, 1, 1]
+        rewards: [0, 0, 0, 0]
+        compareType: 0
+        gameModeFlag: 0
+        numPlayer: 0
+        bookType: 0
+  # Reward item of each book grade, from the AchievementBookReward and
+  # AchievementBookRewardSub tables. Every combination grants exactly one
+  # item and no money, so the shipped data collapses to four item ids.
+  # characterModelId is 10 for the boy and 20 for the girl.
+  bookRewards:
+      - bookType: 1
+        characterModelId: 10
+        itemTids: [30076, 30083, 30075, 30087]
+      - bookType: 1
+        characterModelId: 20
+        itemTids: [10080, 10090, 10085, 10095]
+      - bookType: 2
+        characterModelId: 10
+        itemTids: [30094, 30095, 30070, 30085]
+      - bookType: 2
+        characterModelId: 20
+        itemTids: [10100, 10101, 10089, 10092]
+      - bookType: 3
+        characterModelId: 10
+        itemTids: [30069, 30084, 30068, 30088]
+      - bookType: 3
+        characterModelId: 20
+        itemTids: [10073, 10074, 10083, 10097]
+      - bookType: 4
+        characterModelId: 10
+        itemTids: [30057, 30058, 30079, 30091]
+      - bookType: 4
+        characterModelId: 20
+        itemTids: [10075, 10076, 10084, 10096]
+      - bookType: 5
+        characterModelId: 10
+        itemTids: [30078, 30045, 30077, 30086]
+      - bookType: 5
+        characterModelId: 20
+        itemTids: [10079, 10060, 10086, 10093]
+      - bookType: 6
+        characterModelId: 10
+        itemTids: [30081, 30036, 30080, 30089]
+      - bookType: 6
+        characterModelId: 20
+        itemTids: [10078, 10032, 10087, 10099]
+      - bookType: 7
+        characterModelId: 10
+        itemTids: [30054, 30055, 30072, 30090]
+      - bookType: 7
+        characterModelId: 20
+        itemTids: [10070, 10071, 10082, 10094]
+      - bookType: 8
+        characterModelId: 10
+        itemTids: [30096, 30093, 30073, 30092]
+      - bookType: 8
+        characterModelId: 20
+        itemTids: [10025, 10029, 10081, 10098]

--- a/src/libserver/data/file/FileDataSource.cpp
+++ b/src/libserver/data/file/FileDataSource.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <format>
 #include <fstream>
 #include <regex>
@@ -383,9 +384,24 @@ void server::FileDataSource::RetrieveCharacter(data::Uid uid, data::Character& c
     std::vector<data::Character::AchievementEntry> entries;
     for (const auto& entry : json["achievements"])
     {
-      entries.push_back({.tid = entry["tid"].get<uint16_t>(),
-        .completed = entry.value("completed", false),
-        .progress = entry.value("progress", 0u)});
+      data::Character::AchievementEntry achievement{
+        .tid = entry["tid"].get<uint16_t>(),
+        .progress = entry.value("progress", 0u)};
+
+      if (entry.contains("tierEarnedAt"))
+      {
+        const auto seconds = entry["tierEarnedAt"].get<std::array<int64_t, 4>>();
+        for (size_t tier = 0; tier < seconds.size(); ++tier)
+        {
+          if (seconds[tier] != 0)
+          {
+            achievement.tierEarnedAt[tier] =
+              data::Clock::time_point{std::chrono::seconds{seconds[tier]}};
+          }
+        }
+      }
+
+      entries.push_back(achievement);
     }
     character.achievements = std::move(entries);
   }
@@ -396,9 +412,8 @@ void server::FileDataSource::RetrieveCharacter(data::Uid uid, data::Character& c
     for (const auto& entry : json["achievementBooks"])
     {
       books.push_back({.bookId = entry["bookId"].get<uint8_t>(),
-        .grade = entry.value("grade", static_cast<uint8_t>(0)),
-        .tierProgress = entry.value(
-          "tierProgress", std::array<uint32_t, 4>{})});
+        .tierRewardClaimed = entry.value(
+          "tierRewardClaimed", std::array<uint32_t, 4>{})});
     }
     character.achievementBooks = std::move(books);
   }
@@ -526,9 +541,16 @@ void server::FileDataSource::StoreCharacter(data::Uid uid, const data::Character
     auto achievementsJson = nlohmann::json::array();
     for (const auto& entry : character.achievements())
     {
+      std::array<int64_t, 4> tierEarnedAt{};
+      for (size_t tier = 0; tier < tierEarnedAt.size(); ++tier)
+      {
+        tierEarnedAt[tier] = std::chrono::duration_cast<std::chrono::seconds>(
+          entry.tierEarnedAt[tier].time_since_epoch()).count();
+      }
+
       achievementsJson.push_back({{"tid", entry.tid},
-        {"completed", entry.completed},
-        {"progress", entry.progress}});
+        {"progress", entry.progress},
+        {"tierEarnedAt", tierEarnedAt}});
     }
     json["achievements"] = std::move(achievementsJson);
   }
@@ -538,8 +560,7 @@ void server::FileDataSource::StoreCharacter(data::Uid uid, const data::Character
     for (const auto& entry : character.achievementBooks())
     {
       booksJson.push_back({{"bookId", entry.bookId},
-        {"grade", entry.grade},
-        {"tierProgress", entry.tierProgress}});
+        {"tierRewardClaimed", entry.tierRewardClaimed}});
     }
     json["achievementBooks"] = std::move(booksJson);
   }

--- a/src/libserver/data/file/FileDataSource.cpp
+++ b/src/libserver/data/file/FileDataSource.cpp
@@ -372,6 +372,37 @@ void server::FileDataSource::RetrieveCharacter(data::Uid uid, data::Character& c
 
   character.isRanchLocked = json.value("isRanchLocked", bool{});
 
+  if (json.contains("keyAchievements"))
+  {
+    character.keyAchievements =
+      json["keyAchievements"].get<std::array<uint16_t, 3>>();
+  }
+
+  if (json.contains("achievements"))
+  {
+    std::vector<data::Character::AchievementEntry> entries;
+    for (const auto& entry : json["achievements"])
+    {
+      entries.push_back({.tid = entry["tid"].get<uint16_t>(),
+        .completed = entry.value("completed", false),
+        .progress = entry.value("progress", 0u)});
+    }
+    character.achievements = std::move(entries);
+  }
+
+  if (json.contains("achievementBooks"))
+  {
+    std::vector<data::Character::AchievementBookEntry> books;
+    for (const auto& entry : json["achievementBooks"])
+    {
+      books.push_back({.bookId = entry["bookId"].get<uint8_t>(),
+        .grade = entry.value("grade", static_cast<uint8_t>(0)),
+        .tierProgress = entry.value(
+          "tierProgress", std::array<uint32_t, 4>{})});
+    }
+    character.achievementBooks = std::move(books);
+  }
+
   character.settingsUid = json.value("settingsUid", data::Uid{});
 
   const auto readSkills = [](data::Character::Skills::Sets& sets, const nlohmann::json& json)
@@ -488,6 +519,30 @@ void server::FileDataSource::StoreCharacter(data::Uid uid, const data::Character
   json["housing"] = character.housing();
 
   json["isRanchLocked"] = character.isRanchLocked();
+
+  json["keyAchievements"] = character.keyAchievements();
+
+  {
+    auto achievementsJson = nlohmann::json::array();
+    for (const auto& entry : character.achievements())
+    {
+      achievementsJson.push_back({{"tid", entry.tid},
+        {"completed", entry.completed},
+        {"progress", entry.progress}});
+    }
+    json["achievements"] = std::move(achievementsJson);
+  }
+
+  {
+    auto booksJson = nlohmann::json::array();
+    for (const auto& entry : character.achievementBooks())
+    {
+      booksJson.push_back({{"bookId", entry.bookId},
+        {"grade", entry.grade},
+        {"tierProgress", entry.tierProgress}});
+    }
+    json["achievementBooks"] = std::move(booksJson);
+  }
 
   json["settingsUid"] = character.settingsUid();
 

--- a/src/libserver/data/helper/ProtocolHelper.cpp
+++ b/src/libserver/data/helper/ProtocolHelper.cpp
@@ -38,6 +38,22 @@ Horse::HorseType HorseTypeToProtocolHorseType(
 
 } // anon namespace
 
+uint32_t BuildProtocolAchievementDate(const data::Clock::time_point timePoint)
+{
+  if (timePoint == data::Clock::time_point{})
+    return 0;
+
+  const auto localTime = std::chrono::current_zone()->to_local(timePoint);
+  const std::chrono::year_month_day date{
+    std::chrono::floor<std::chrono::days>(localTime)};
+
+  const auto year = static_cast<uint32_t>(static_cast<int32_t>(date.year()));
+  const auto month = static_cast<uint32_t>(static_cast<unsigned>(date.month()));
+  const auto day = static_cast<uint32_t>(static_cast<unsigned>(date.day()));
+
+  return (year & 0xFFF) | ((month & 0xF) << 12) | ((day & 0x1F) << 16);
+}
+
 void BuildProtocolCharacter(
   Character& protocolCharacter,
   const data::Character& character)
@@ -406,12 +422,12 @@ void BuildProtocolQuest(
   Quest& protocolQuest,
   const data::Quest& quest)
 {
-  protocolQuest.tid      = static_cast<uint16_t>(quest.questId());
-  protocolQuest.member0  = 0;
-  protocolQuest.status   = static_cast<Quest::Status>(quest.isCompleted());
-  protocolQuest.progress = quest.progress();
-  protocolQuest.member3  = 0;
-  protocolQuest.member4  = 0;
+  protocolQuest.tid         = static_cast<uint16_t>(quest.questId());
+  protocolQuest.completedAt = 0;
+  protocolQuest.status      = static_cast<Quest::Status>(quest.isCompleted());
+  protocolQuest.progress    = quest.progress();
+  protocolQuest.tier        = 0;
+  protocolQuest.member4     = 0;
 }
 
 void BuildProtocolQuests(

--- a/src/libserver/network/command/proto/CommonStructureDefinitions.cpp
+++ b/src/libserver/network/command/proto/CommonStructureDefinitions.cpp
@@ -706,20 +706,20 @@ void RanchCharacter::Read(RanchCharacter& value, SourceStream& stream)
 void Quest::Write(const Quest& value, SinkStream& stream)
 {
   stream.Write(value.tid)
-    .Write(value.member0)
+    .Write(value.completedAt)
     .Write(value.status)
     .Write(value.progress)
-    .Write(value.member3)
+    .Write(value.tier)
     .Write(value.member4);
 }
 
 void Quest::Read(Quest& value, SourceStream& stream)
 {
   stream.Read(value.tid)
-    .Read(value.member0)
+    .Read(value.completedAt)
     .Read(reinterpret_cast<uint8_t&>(value.status))
     .Read(value.progress)
-    .Read(value.member3)
+    .Read(value.tier)
     .Read(value.member4);
 }
 

--- a/src/libserver/network/command/proto/LobbyMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/LobbyMessageDefinitions.cpp
@@ -383,11 +383,22 @@ void AcCmdCLAchievementCompleteListOK::Write(
   const AcCmdCLAchievementCompleteListOK& command,
   SinkStream& stream)
 {
-  stream.Write(command.unk0);
+  stream.Write(command.characterUid);
   stream.Write(static_cast<uint16_t>(command.achievements.size()));
   for (const auto& achievement : command.achievements)
   {
     stream.Write(achievement);
+  }
+
+  stream.Write(static_cast<uint8_t>(command.books.size()));
+  for (const auto& book : command.books)
+  {
+    stream.Write(book.bookId)
+      .Write(book.grade);
+    for (const auto& progress : book.tierProgress)
+    {
+      stream.Write(progress);
+    }
   }
 }
 
@@ -1154,9 +1165,9 @@ void AcCmdLCPersonalInfo::Basic::Write(
     .Write(command.completionRate)
     .Write(command.member12)
     .Write(command.highestCarnivalPrize)
-    .Write(command.member14)
-    .Write(command.member15)
-    .Write(command.member16)
+    .Write(command.keyAchievements[0])
+    .Write(command.keyAchievements[1])
+    .Write(command.keyAchievements[2])
     .Write(command.introduction)
     .Write(command.level)
     .Write(command.levelProgress)

--- a/src/libserver/network/command/proto/LobbyMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/LobbyMessageDefinitions.cpp
@@ -19,6 +19,8 @@
 
 #include "libserver/network/command/proto/LobbyMessageDefinitions.hpp"
 
+#include <cassert>
+
 namespace server::protocol
 {
 
@@ -390,14 +392,17 @@ void AcCmdCLAchievementCompleteListOK::Write(
     stream.Write(achievement);
   }
 
+  if (command.books.size() > MaxAchievementBooks)
+    throw std::runtime_error("Achievement book count is over the limit");
+
   stream.Write(static_cast<uint8_t>(command.books.size()));
   for (const auto& book : command.books)
   {
     stream.Write(book.bookId)
       .Write(book.grade);
-    for (const auto& progress : book.tierProgress)
+    for (const auto& claimed : book.tierRewardClaimed)
     {
-      stream.Write(progress);
+      stream.Write(claimed);
     }
   }
 }

--- a/src/libserver/network/command/proto/RaceMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RaceMessageDefinitions.cpp
@@ -776,7 +776,7 @@ void AcCmdRCRaceResultNotify::Write(
       .Write(score.teamColor)
       .Write(score.member10)
       .Write(score.member11)
-      .Write(score.member12)
+      .Write(score.points)
       .Write(score.recordTimeDifference)
       .Write(score.levelProgress)
       .Write(score.horseClassProgress)

--- a/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
@@ -1967,7 +1967,7 @@ void AcCmdCRAchievementUpdateProperty::Read(
   SourceStream& stream)
 {
   stream.Read(command.achievementEvent)
-    .Read(command.member2);
+    .Read(command.propertyValue);
 }
 
 void AcCmdCRHousingBuild::Write(
@@ -3648,9 +3648,9 @@ void AcCmdCRAchievementDetailOK::Write(
 {
   stream.Write(command.characterUid)
     .Write(command.achievementTid);
-  for (const auto& progress : command.tierProgress)
+  for (const auto& earnedDate : command.tierEarnedDates)
   {
-    stream.Write(progress);
+    stream.Write(earnedDate);
   }
 }
 
@@ -3670,6 +3670,51 @@ void AcCmdCRAchievementDetailCancel::Write(
 
 void AcCmdCRAchievementDetailCancel::Read(
   AcCmdCRAchievementDetailCancel&,
+  SourceStream&)
+{
+  // Empty.
+}
+
+void AcCmdCRAchievementBookReward::Write(
+  const AcCmdCRAchievementBookReward&,
+  SinkStream&)
+{
+  throw std::runtime_error("Not implemented");
+}
+
+void AcCmdCRAchievementBookReward::Read(
+  AcCmdCRAchievementBookReward& command,
+  SourceStream& stream)
+{
+  stream.Read(command.bookType)
+    .Read(command.grade);
+}
+
+void AcCmdCRAchievementBookRewardOK::Write(
+  const AcCmdCRAchievementBookRewardOK& command,
+  SinkStream& stream)
+{
+  stream.Write(command.bookType)
+    .Write(command.grade)
+    .Write(command.item);
+}
+
+void AcCmdCRAchievementBookRewardOK::Read(
+  AcCmdCRAchievementBookRewardOK&,
+  SourceStream&)
+{
+  throw std::runtime_error("Not implemented");
+}
+
+void AcCmdCRAchievementBookRewardCancel::Write(
+  const AcCmdCRAchievementBookRewardCancel&,
+  SinkStream&)
+{
+  // Empty.
+}
+
+void AcCmdCRAchievementBookRewardCancel::Read(
+  AcCmdCRAchievementBookRewardCancel&,
   SourceStream&)
 {
   // Empty.

--- a/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
+++ b/src/libserver/network/command/proto/RanchMessageDefinitions.cpp
@@ -3627,5 +3627,98 @@ void AcCmdCRBreedingWishlistDelOK::Read(
   throw std::runtime_error("Not implemented");
 }
 
+void AcCmdCRAchievementDetail::Write(
+  const AcCmdCRAchievementDetail&,
+  SinkStream&)
+{
+  throw std::runtime_error("Not implemented");
+}
+
+void AcCmdCRAchievementDetail::Read(
+  AcCmdCRAchievementDetail& command,
+  SourceStream& stream)
+{
+  stream.Read(command.characterUid)
+    .Read(command.achievementTid);
+}
+
+void AcCmdCRAchievementDetailOK::Write(
+  const AcCmdCRAchievementDetailOK& command,
+  SinkStream& stream)
+{
+  stream.Write(command.characterUid)
+    .Write(command.achievementTid);
+  for (const auto& progress : command.tierProgress)
+  {
+    stream.Write(progress);
+  }
+}
+
+void AcCmdCRAchievementDetailOK::Read(
+  AcCmdCRAchievementDetailOK&,
+  SourceStream&)
+{
+  throw std::runtime_error("Not implemented");
+}
+
+void AcCmdCRAchievementDetailCancel::Write(
+  const AcCmdCRAchievementDetailCancel&,
+  SinkStream&)
+{
+  // Empty.
+}
+
+void AcCmdCRAchievementDetailCancel::Read(
+  AcCmdCRAchievementDetailCancel&,
+  SourceStream&)
+{
+  // Empty.
+}
+
+void AcCmdCRSetKeyAchievement::Write(
+  const AcCmdCRSetKeyAchievement&,
+  SinkStream&)
+{
+  throw std::runtime_error("Not implemented");
+}
+
+void AcCmdCRSetKeyAchievement::Read(
+  AcCmdCRSetKeyAchievement& command,
+  SourceStream& stream)
+{
+  for (auto& achievement : command.keyAchievements)
+  {
+    stream.Read(achievement);
+  }
+}
+
+void AcCmdCRSetKeyAchievementOK::Write(
+  const AcCmdCRSetKeyAchievementOK&,
+  SinkStream&)
+{
+  // Empty.
+}
+
+void AcCmdCRSetKeyAchievementOK::Read(
+  AcCmdCRSetKeyAchievementOK&,
+  SourceStream&)
+{
+  // Empty.
+}
+
+void AcCmdCRSetKeyAchievementCancel::Write(
+  const AcCmdCRSetKeyAchievementCancel&,
+  SinkStream&)
+{
+  // Empty.
+}
+
+void AcCmdCRSetKeyAchievementCancel::Read(
+  AcCmdCRSetKeyAchievementCancel&,
+  SourceStream&)
+{
+  // Empty.
+}
+
 } // namespace server::protocol
 

--- a/src/libserver/registry/AchievementRegistry.cpp
+++ b/src/libserver/registry/AchievementRegistry.cpp
@@ -1,0 +1,113 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2024 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#include "libserver/registry/AchievementRegistry.hpp"
+
+#include <spdlog/spdlog.h>
+#include <yaml-cpp/yaml.h>
+
+#include <stdexcept>
+
+namespace server::registry
+{
+
+namespace
+{
+
+void ReadAchievement(
+  const YAML::Node& section,
+  AchievementInfo& info)
+{
+  info.tid = section["tid"].as<uint16_t>();
+  info.eventId = section["eventId"].as<uint16_t>();
+  info.function = section["function"].as<std::string>();
+  info.successValue = section["successValue"].as<uint32_t>();
+  info.bookType = section["bookType"].as<uint8_t>();
+  info.reward = section["reward"].as<uint32_t>();
+  info.points = section["points"].as<uint32_t>();
+}
+
+} // namespace
+
+AchievementRegistry::AchievementRegistry()
+{
+  // Empty.
+}
+
+void AchievementRegistry::ReadConfig(
+  const std::filesystem::path& configPath)
+{
+  const auto root = YAML::LoadFile(configPath.string());
+
+  const auto achievementsSection = root["achievements"];
+  if (not achievementsSection)
+    throw std::runtime_error("Missing achievements section");
+
+  const auto collection = achievementsSection["collection"];
+  if (not collection)
+    throw std::runtime_error("Missing achievements collection");
+
+  for (const auto& entry : collection)
+  {
+    AchievementInfo info;
+    ReadAchievement(entry, info);
+
+    const auto tid = info.tid;
+    const auto eventId = info.eventId;
+
+    _achievements.emplace(tid, std::move(info));
+    _eventToTids.emplace(eventId, tid);
+  }
+
+  spdlog::info(
+    "Achievement registry loaded {} achievements",
+    _achievements.size());
+}
+
+std::vector<const AchievementInfo*>
+AchievementRegistry::GetAchievementsByEvent(
+  const uint16_t eventId) const
+{
+  std::vector<const AchievementInfo*> result;
+  const auto range = _eventToTids.equal_range(eventId);
+
+  for (auto it = range.first; it != range.second; ++it)
+  {
+    const auto achievementIt = _achievements.find(it->second);
+    if (achievementIt != _achievements.end())
+    {
+      result.push_back(&achievementIt->second);
+    }
+  }
+
+  return result;
+}
+
+const AchievementInfo* AchievementRegistry::GetAchievement(
+  const uint16_t tid) const
+{
+  const auto it = _achievements.find(tid);
+  if (it == _achievements.end())
+  {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+} // namespace server::registry

--- a/src/libserver/registry/AchievementRegistry.cpp
+++ b/src/libserver/registry/AchievementRegistry.cpp
@@ -22,6 +22,8 @@
 #include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
 
+#include <algorithm>
+#include <limits>
 #include <stdexcept>
 
 namespace server::registry
@@ -30,20 +32,199 @@ namespace server::registry
 namespace
 {
 
+//! Reads a fixed size sequence, tolerating a shorter or missing one so that
+//! achievements which only define the first tiers stay valid.
+//! @param node The sequence node.
+//! @param values The destination, entries beyond the sequence stay zero.
+void ReadTierValues(
+  const YAML::Node& node,
+  std::array<uint32_t, AchievementTierCount>& values)
+{
+  if (not node)
+    return;
+
+  const auto count = std::min<size_t>(node.size(), values.size());
+  for (size_t tier = 0; tier < count; ++tier)
+  {
+    values[tier] = node[tier].as<uint32_t>(0);
+  }
+}
+
 void ReadAchievement(
   const YAML::Node& section,
   AchievementInfo& info)
 {
   info.tid = section["tid"].as<uint16_t>();
-  info.eventId = section["eventId"].as<uint16_t>();
-  info.function = section["function"].as<std::string>();
-  info.successValue = section["successValue"].as<uint32_t>();
-  info.bookType = section["bookType"].as<uint8_t>();
-  info.reward = section["reward"].as<uint32_t>();
-  info.points = section["points"].as<uint32_t>();
+  // Until a condition reading names another event, an achievement is measured
+  // by the one that triggers it.
+  info.measuredEventId = section["eventId"].as<uint16_t>();
+  info.function = section["function"].as<std::string>("");
+  info.functionValue = section["functionValue"].as<uint32_t>(0);
+  info.resetFunction = section["resetFunction"].as<std::string>("");
+  info.resetEventId = static_cast<uint16_t>(
+    section["resetEventId"].as<uint32_t>(0));
+  info.compareType = static_cast<CompareType>(
+    section["compareType"].as<uint32_t>(0));
+  info.gameModeFlag = static_cast<uint8_t>(
+    section["gameModeFlag"].as<uint32_t>(0));
+  info.numPlayer = static_cast<uint8_t>(section["numPlayer"].as<uint32_t>(0));
+  // yaml-cpp resolves the narrow character types as characters, so read the
+  // signed field as an int and narrow it afterwards.
+  info.bookType = static_cast<int8_t>(section["bookType"].as<int32_t>(0));
+
+  ReadTierValues(section["successValues"], info.successValues);
+  ReadTierValues(section["rewards"], info.rewards);
+}
+
+//! Turns the name a condition reading carries into its kind.
+//! @param name The name from the configuration.
+//! @returns The kind, Direct for an unknown or missing name.
+ConditionKind ParseConditionKind(const std::string& name)
+{
+  if (name == "never")
+    return ConditionKind::Never;
+  if (name == "atLeast")
+    return ConditionKind::AtLeast;
+  if (name == "atMost")
+    return ConditionKind::AtMost;
+
+  return ConditionKind::Direct;
+}
+
+void ReadBookReward(
+  const YAML::Node& section,
+  AchievementBookRewardInfo& info)
+{
+  info.bookType = static_cast<int8_t>(section["bookType"].as<int32_t>(0));
+  info.characterModelId = static_cast<uint8_t>(
+    section["characterModelId"].as<uint32_t>(0));
+
+  ReadTierValues(section["itemTids"], info.itemTids);
 }
 
 } // namespace
+
+GameModeFlag ToGameModeFlag(
+  const bool isMagic,
+  const bool isTeam,
+  const bool isMission)
+{
+  if (isMission)
+    return GameModeFlag::Mission;
+
+  if (isMagic)
+    return isTeam ? GameModeFlag::MagicTeam : GameModeFlag::MagicSingle;
+
+  return isTeam ? GameModeFlag::SpeedTeam : GameModeFlag::SpeedSingle;
+}
+
+bool AchievementInfo::IsLowerBetter() const
+{
+  return compareType == CompareType::Minimum;
+}
+
+bool AchievementInfo::IsGated() const
+{
+  return conditionKind == ConditionKind::AtLeast
+    or conditionKind == ConditionKind::AtMost;
+}
+
+bool AchievementInfo::PassesBar(const uint32_t value) const
+{
+  if (conditionKind == ConditionKind::AtLeast)
+    return value >= conditionBar;
+
+  if (conditionKind == ConditionKind::AtMost)
+    return value != 0 and value <= conditionBar;
+
+  return true;
+}
+
+bool AchievementInfo::CountsInMode(const GameModeFlag mode) const
+{
+  // 94 of the 246 achievements name no mode, and those count everywhere.
+  if (gameModeFlag == 0)
+    return true;
+
+  return (gameModeFlag & static_cast<uint8_t>(mode)) != 0;
+}
+
+uint8_t AchievementInfo::GetReachedTierCount(const uint32_t progress) const
+{
+  const bool lowerIsBetter = IsLowerBetter();
+
+  uint8_t reached = 0;
+  for (size_t tier = 0; tier < successValues.size(); ++tier)
+  {
+    // 114 achievements carry no threshold and reward only the first tier, so a
+    // missing first threshold counts as one. On a later tier it means the
+    // achievement does not use that tier.
+    uint32_t threshold = successValues[tier];
+    if (threshold == 0)
+    {
+      if (tier > 0)
+        break;
+
+      threshold = 1;
+    }
+
+    // Where less is better a progress of zero means nothing was reported yet
+    // rather than a perfect result.
+    const bool met = lowerIsBetter
+      ? progress != 0 and progress <= threshold
+      : progress >= threshold;
+
+    if (not met)
+      break;
+
+    ++reached;
+  }
+
+  return reached;
+}
+
+uint32_t AchievementInfo::CombineProgress(
+  const uint32_t stored,
+  const uint32_t reported,
+  const uint32_t lastReported) const
+{
+  switch (compareType)
+  {
+    case CompareType::Minimum:
+    {
+      // A lower value wins, but zero stands for "nothing reported yet" on
+      // either side, so it must not overwrite a stored result.
+      if (reported == 0)
+        return stored;
+
+      if (stored == 0)
+        return reported;
+
+      return std::min(stored, reported);
+    }
+
+    case CompareType::Maximum:
+      return std::max(stored, reported);
+
+    case CompareType::Count:
+    case CompareType::Sum:
+    default:
+    {
+      // The client counts cumulatively within one race and starts a fresh
+      // count in the next, and the last report is forgotten when a race
+      // starts, so only the growth since the last one is new progress.
+      const uint32_t gained = reported > lastReported
+        ? reported - lastReported
+        : 0;
+
+      // Saturate rather than wrap, a total is never meant to fall.
+      if (stored > std::numeric_limits<uint32_t>::max() - gained)
+        return std::numeric_limits<uint32_t>::max();
+
+      return stored + gained;
+    }
+  }
+}
 
 AchievementRegistry::AchievementRegistry()
 {
@@ -69,36 +250,116 @@ void AchievementRegistry::ReadConfig(
     ReadAchievement(entry, info);
 
     const auto tid = info.tid;
-    const auto eventId = info.eventId;
-
     _achievements.emplace(tid, std::move(info));
-    _eventToTids.emplace(eventId, tid);
+  }
+
+  RebuildEventIndex();
+
+  for (const auto& entry : achievementsSection["bookRewards"])
+  {
+    AchievementBookRewardInfo info;
+    ReadBookReward(entry, info);
+    _bookRewards.emplace_back(info);
   }
 
   spdlog::info(
-    "Achievement registry loaded {} achievements",
-    _achievements.size());
+    "Achievement registry loaded {} achievements and {} book rewards",
+    _achievements.size(),
+    _bookRewards.size());
 }
 
-std::vector<const AchievementInfo*>
-AchievementRegistry::GetAchievementsByEvent(
-  const uint16_t eventId) const
+void AchievementRegistry::RebuildEventIndex()
 {
-  std::vector<const AchievementInfo*> result;
-  const auto range = _eventToTids.equal_range(eventId);
-
-  for (auto it = range.first; it != range.second; ++it)
+  // Achievements are looked up by the event that measures them, which is what
+  // a report carries. The lists hold pointers into the map, which stays valid
+  // because nothing is inserted once the configuration has been read.
+  _byEvent.clear();
+  _byBook.clear();
+  for (const auto& [tid, info] : _achievements)
   {
-    const auto achievementIt = _achievements.find(it->second);
-    if (achievementIt != _achievements.end())
+    _byEvent[info.measuredEventId].push_back(&info);
+    _byBook[info.bookType].push_back(&info);
+  }
+}
+
+void AchievementRegistry::ReadConditions(
+  const std::filesystem::path& configPath)
+{
+  const auto root = YAML::LoadFile(configPath.string());
+
+  const auto conditions = root["conditions"];
+  if (not conditions)
+    throw std::runtime_error("Missing conditions section");
+
+  for (const auto& entry : root["thresholds"])
+  {
+    const auto tid = entry["tid"].as<uint16_t>();
+    const auto achievement = _achievements.find(tid);
+    if (achievement == _achievements.end())
+      throw std::runtime_error("Threshold for unknown achievement");
+
+    ReadTierValues(entry["successValues"], achievement->second.successValues);
+  }
+
+  size_t readingCount = 0;
+
+  for (const auto& entry : conditions)
+  {
+    const auto function = entry["function"].as<std::string>();
+    const auto kind = ParseConditionKind(entry["kind"].as<std::string>(""));
+    const auto measuredEventId = static_cast<uint16_t>(
+      entry["measuredEvent"].as<uint32_t>(0));
+
+    // A bar given per achievement overrides the column, and its absence means
+    // the column carries it.
+    std::unordered_map<uint16_t, uint32_t> bars;
+    bool barsGiven = false;
+    for (const auto& bar : entry["bars"])
     {
-      result.push_back(&achievementIt->second);
+      barsGiven = true;
+      bars.emplace(bar["tid"].as<uint16_t>(), bar["bar"].as<uint32_t>(0));
+    }
+
+    for (auto& [tid, info] : _achievements)
+    {
+      if (info.function != function)
+        continue;
+
+      // A function may be listed with bars for only some of the achievements
+      // that carry it, and the others keep the plain reading.
+      if (barsGiven and not bars.contains(tid))
+        continue;
+
+      info.conditionKind = kind;
+      if (measuredEventId != 0)
+        info.measuredEventId = measuredEventId;
+
+      const auto bar = bars.find(tid);
+      info.conditionBar = bar != bars.end() and bar->second != 0
+        ? bar->second
+        : info.functionValue;
+
+      ++readingCount;
     }
   }
 
-  return result;
+  RebuildEventIndex();
+
+  spdlog::info(
+    "Achievement registry applied {} condition readings",
+    readingCount);
 }
 
+std::span<const AchievementInfo* const>
+AchievementRegistry::GetAchievementsByEvent(
+  const uint16_t eventId) const
+{
+  const auto it = _byEvent.find(eventId);
+  if (it == _byEvent.end())
+    return {};
+
+  return it->second;
+}
 const AchievementInfo* AchievementRegistry::GetAchievement(
   const uint16_t tid) const
 {
@@ -108,6 +369,43 @@ const AchievementInfo* AchievementRegistry::GetAchievement(
     return nullptr;
   }
   return &it->second;
+}
+
+std::span<const AchievementInfo* const>
+AchievementRegistry::GetAchievementsByBook(
+  const int8_t bookType) const
+{
+  const auto it = _byBook.find(bookType);
+  if (it == _byBook.end())
+    return {};
+
+  return it->second;
+}
+double AchievementRegistry::GetReportedValueScale(const uint16_t eventId) const
+{
+  const auto scale = _reportedValueScales.find(eventId);
+  if (scale == _reportedValueScales.end())
+    return 1.0;
+
+  return scale->second;
+}
+
+const AchievementBookRewardInfo* AchievementRegistry::GetBookReward(
+  const int8_t bookType,
+  const uint8_t characterModelId) const
+{
+  const auto reward = std::ranges::find_if(
+    _bookRewards,
+    [bookType, characterModelId](const AchievementBookRewardInfo& info)
+    {
+      return info.bookType == bookType
+        and info.characterModelId == characterModelId;
+    });
+
+  if (reward == _bookRewards.end())
+    return nullptr;
+
+  return &*reward;
 }
 
 } // namespace server::registry

--- a/src/server/ServerInstance.cpp
+++ b/src/server/ServerInstance.cpp
@@ -56,6 +56,7 @@ ServerInstance::ServerInstance(
   , _matchmakingSystem(*this)
   , _questSystem(*this)
   , _rewardSystem(*this)
+  , _achievementSystem(*this)
   , _telemetry(*this)
   , _breedingMarket(*this)
   , _genetics(*this)
@@ -290,6 +291,8 @@ void ServerInstance::LoadConfigurations()
 
   // Read game configurations
   _achievementRegistry.ReadConfig(_resourceDirectory / "config/game/achievements.yaml");
+  _achievementRegistry.ReadConditions(
+    _resourceDirectory / "config/game/achievement-conditions.yaml");
   _breedingRegistry.ReadConfig(_resourceDirectory / "config/game/breeding.yaml");
   _characterRegistry.ReadConfig(_resourceDirectory / "config/game/character.yaml");
   _courseRegistry.ReadConfig(_resourceDirectory / "config/game/courses.yaml");
@@ -428,6 +431,11 @@ MatchmakingSystem& ServerInstance::GetMatchmakingSystem()
 RewardSystem& ServerInstance::GetRewardSystem()
 {
   return _rewardSystem;
+}
+
+AchievementSystem& ServerInstance::GetAchievementSystem()
+{
+  return _achievementSystem;
 }
 
 QuestSystem& ServerInstance::GetQuestSystem()

--- a/src/server/ServerInstance.cpp
+++ b/src/server/ServerInstance.cpp
@@ -289,6 +289,7 @@ void ServerInstance::LoadConfigurations()
   _systemContentRegistry.ReadConfig(_resourceDirectory / "config/server/system_content.yaml");
 
   // Read game configurations
+  _achievementRegistry.ReadConfig(_resourceDirectory / "config/game/achievements.yaml");
   _breedingRegistry.ReadConfig(_resourceDirectory / "config/game/breeding.yaml");
   _characterRegistry.ReadConfig(_resourceDirectory / "config/game/character.yaml");
   _courseRegistry.ReadConfig(_resourceDirectory / "config/game/courses.yaml");
@@ -337,6 +338,11 @@ AllChatDirector& ServerInstance::GetAllChatDirector()
 PrivateChatDirector& ServerInstance::GetPrivateChatDirector()
 {
   return _privateChatDirector;
+}
+
+registry::AchievementRegistry& ServerInstance::GetAchievementRegistry()
+{
+  return _achievementRegistry;
 }
 
 registry::CharacterRegistry& ServerInstance::GetCharacterRegistry()

--- a/src/server/lobby/LobbyDirector.cpp
+++ b/src/server/lobby/LobbyDirector.cpp
@@ -21,6 +21,7 @@
 
 #include "server/lobby/LobbyNetworkHandler.hpp"
 #include "server/ServerInstance.hpp"
+#include "server/system/AchievementSystem.hpp"
 
 namespace server
 {
@@ -144,6 +145,19 @@ void LobbyDirector::QueueClientLogout(
     {
       user.lastSeenOnline() = data::Clock::now();
     });
+  }
+
+  const auto userIter = _userInstances.find(userName);
+  if (userIter != _userInstances.cend())
+  {
+    // The reported achievement values have to survive the switch between the
+    // ranch and the race connection, so they are only dropped once the
+    // character leaves the game entirely.
+    _serverInstance.GetAchievementSystem().ForgetReportedValues(
+      userIter->second.characterUid);
+
+    _serverInstance.GetAchievementSystem().ApplySessionEnd(
+      userIter->second.characterUid);
   }
 
   _userInstances.erase(userName);

--- a/src/server/lobby/LobbyNetworkHandler.cpp
+++ b/src/server/lobby/LobbyNetworkHandler.cpp
@@ -20,6 +20,7 @@
 #include "server/lobby/LobbyNetworkHandler.hpp"
 
 #include "server/ServerInstance.hpp"
+#include "server/system/AchievementSystem.hpp"
 
 #include <libserver/data/helper/ProtocolHelper.hpp>
 
@@ -37,6 +38,11 @@ namespace
 
 //! A random device for random number generation.
 std::random_device rd;
+
+//! Tier index that tells the client no tier of an achievement was reached.
+//! The client sign-extends the byte, so this arrives as -1, which is the value
+//! it checks for before marking any tier as earned.
+constexpr uint8_t NoAchievementTier = 0xFFu;
 
 } // anon namespace
 
@@ -1955,28 +1961,56 @@ void LobbyNetworkHandler::HandleAchievementCompleteList(
   protocol::AcCmdCLAchievementCompleteListOK response{};
 
   characterRecord.Immutable(
-    [&response](const data::Character& character)
+    [this, &response](const data::Character& character)
     {
       response.characterUid = character.uid();
 
       for (const auto& entry : character.achievements())
       {
+        const auto earnedTiers = AchievementSystem::GetEarnedTierCount(entry);
+
         auto& quest = response.achievements.emplace_back();
         quest.tid = entry.tid;
-        // TODO: the status enum arrived with the quest work after this was
-        // written. ReadyToClaim keeps the value this used to send, but an
-        // achievement has no claim step, so Finished may be the correct one.
-        quest.status = entry.completed
+        // The client tests for exactly 1 and marks the earned tiers on it. Any
+        // other value falls into a path that only marks a tier when the
+        // progress happens to match the threshold the client has compiled in.
+        quest.status = earnedTiers > 0
           ? protocol::Quest::ReadyToClaim
           : protocol::Quest::InProgress;
         quest.progress = entry.progress;
+        // Highest earned tier, or 0xFF which the client reads as -1 for none.
+        quest.tier = earnedTiers > 0
+          ? static_cast<uint8_t>(earnedTiers - 1)
+          : NoAchievementTier;
+        // The client only takes the date over on the status above, which is
+        // exactly when a tier has been earned.
+        if (earnedTiers > 0)
+          quest.completedAt = protocol::BuildProtocolAchievementDate(
+            entry.tierEarnedAt[earnedTiers - 1]);
       }
 
-      for (const auto& book : character.achievementBooks())
+      // One entry per book the client renders, which is exactly the limit it
+      // accepts. A longer list makes it drop the whole command.
+      static_assert(
+        protocol::MaxAchievementBooks == registry::AchievementBookTypeCount);
+
+      const auto& achievementSystem = _serverInstance.GetAchievementSystem();
+      const auto& books = character.achievementBooks();
+
+      for (uint8_t bookType = 0;
+           bookType < registry::AchievementBookTypeCount;
+           ++bookType)
       {
-        response.books.push_back({.bookId = book.bookId,
-          .grade = book.grade,
-          .tierProgress = book.tierProgress});
+        auto& bookEntry = response.books.emplace_back();
+        bookEntry.bookId = bookType;
+        bookEntry.grade = achievementSystem.GetBookGrade(
+          character, static_cast<int8_t>(bookType));
+
+        const auto storedBook = std::ranges::find(
+          books, bookType, &data::Character::AchievementBookEntry::bookId);
+
+        if (storedBook != books.end())
+          bookEntry.tierRewardClaimed = storedBook->tierRewardClaimed;
       }
     });
 
@@ -2612,10 +2646,10 @@ void LobbyNetworkHandler::HandleRequestDailyQuestList(
       // Daily quests go into unk[2..4] (slots 0 and 1 are the two Repeatable quests).
       response.unk[i + 2] = protocol::Quest{
         /*tid=*/questId,
-        /*member0=*/0,
+        /*completedAt=*/0,
         isDone ? protocol::Quest::Status::ReadyToClaim : protocol::Quest::Status::InProgress,
         /*progress=*/progress,
-        /*member3=*/0,
+        /*tier=*/0,
         /*member4=*/0};
     }
   });

--- a/src/server/lobby/LobbyNetworkHandler.cpp
+++ b/src/server/lobby/LobbyNetworkHandler.cpp
@@ -1957,15 +1957,28 @@ void LobbyNetworkHandler::HandleAchievementCompleteList(
   characterRecord.Immutable(
     [&response](const data::Character& character)
     {
-      response.unk0 = character.uid();
-    });
+      response.characterUid = character.uid();
 
-  // These are the level-up achievements from the `Achievement` table with the event id 75.
-  response.achievements.emplace_back().tid = 20008;
-  response.achievements.emplace_back().tid = 20009;
-  response.achievements.emplace_back().tid = 20010;
-  response.achievements.emplace_back().tid = 20011;
-  response.achievements.emplace_back().tid = 20012;
+      for (const auto& entry : character.achievements())
+      {
+        auto& quest = response.achievements.emplace_back();
+        quest.tid = entry.tid;
+        // TODO: the status enum arrived with the quest work after this was
+        // written. ReadyToClaim keeps the value this used to send, but an
+        // achievement has no claim step, so Finished may be the correct one.
+        quest.status = entry.completed
+          ? protocol::Quest::ReadyToClaim
+          : protocol::Quest::InProgress;
+        quest.progress = entry.progress;
+      }
+
+      for (const auto& book : character.achievementBooks())
+      {
+        response.books.push_back({.bookId = book.bookId,
+          .grade = book.grade,
+          .tierProgress = book.tierProgress});
+      }
+    });
 
   _commandServer.QueueCommand<decltype(response)>(
     clientId,
@@ -2005,6 +2018,7 @@ void LobbyNetworkHandler::HandleRequestPersonalInfo(
         response.basic.introduction = character.introduction();
         response.basic.level = character.level();
         response.basic.levelProgress = character.experience();
+        response.basic.keyAchievements = character.keyAchievements();
         // TODO: implement other stats
         break;
       }

--- a/src/server/race/RaceNetworkHandler.cpp
+++ b/src/server/race/RaceNetworkHandler.cpp
@@ -19,6 +19,7 @@
 
 #include "server/race/MagicSystem.hpp"
 #include "server/race/RaceNetworkHandler.hpp"
+#include "server/system/AchievementSystem.hpp"
 #include "server/system/PotentialSystem.hpp"
 
 #include "server/ServerInstance.hpp"
@@ -44,6 +45,12 @@ RaceNetworkHandler::RaceNetworkHandler(ServerInstance& serverInstance)
     [this](ClientId clientId, const auto& message)
     {
       HandleEnterRoom(clientId, message);
+    });
+
+  _commandServer.RegisterCommandHandler<protocol::AcCmdCRAchievementUpdateProperty>(
+    [this](ClientId clientId, const auto& message)
+    {
+      HandleAchievementUpdateProperty(clientId, message);
     });
 
   _commandServer.RegisterCommandHandler<protocol::AcCmdCRChangeRoomOptions>(
@@ -1379,6 +1386,11 @@ void RaceNetworkHandler::HandleStartRace(
         if (racer.state == tracker::RaceTracker::Racer::State::Disconnected)
           continue;
 
+        // The client counts within a race and starts over in the next one, so
+        // the previous race must not carry over. This also makes what arrives
+        // from here on the statistic the result conditions read.
+        _serverInstance.GetAchievementSystem().ForgetReportedValues(characterUid);
+
         std::string characterName;
         GetServerInstance().GetDataDirector().GetCharacter(characterUid).Immutable(
           [&characterName](const data::Character& character)
@@ -1718,6 +1730,55 @@ void RaceNetworkHandler::HandleUserRaceFinal(
     .courseTime = racer.courseTime};
 
   this->Broadcast(raceInstance, notify);
+
+  AwardRaceAchievements(clientId, raceInstance, not didNotFinish);
+}
+
+void RaceNetworkHandler::AwardRaceAchievements(
+  const ClientId clientId,
+  RaceInstance& raceInstance,
+  const bool finished)
+{
+  const auto& clientContext = GetClientContext(clientId);
+  const auto& racers = raceInstance.GetTracker().GetRacers();
+
+  // The place is how many racers already reached the goal, plus this one. The
+  // racer's own state is set before this runs, so they are counted too.
+  uint8_t finisherCount = 0;
+  for (const auto& other : racers | std::views::values)
+  {
+    if (other.courseTime != tracker::InvalidCourseTime)
+      ++finisherCount;
+  }
+
+  const auto localNow = std::chrono::current_zone()->to_local(
+    data::Clock::now());
+  const std::chrono::hh_mm_ss timeOfDay{
+    localNow - std::chrono::floor<std::chrono::days>(localNow)};
+
+  const AchievementSystem::RaceOutcome outcome{
+    .mode = registry::ToGameModeFlag(
+      raceInstance.GetParameters().gameMode == protocol::GameMode::Magic,
+      raceInstance.GetParameters().teamMode == protocol::TeamMode::Team,
+      raceInstance.GetParameters().missionId != 0),
+    .racerCount = static_cast<uint8_t>(racers.size()),
+    .placement = finished ? finisherCount : uint8_t{0},
+    .finished = finished,
+    .hourOfDay = static_cast<uint8_t>(timeOfDay.hours().count())};
+
+  const auto updates = _serverInstance.GetAchievementSystem().ApplyRaceOutcome(
+    clientContext.characterUid, outcome);
+
+  for (const auto& update : updates)
+  {
+    const auto notify = AchievementSystem::BuildUpdateNotify(update);
+
+    _commandServer.QueueCommand<decltype(notify)>(
+      clientId, [notify]()
+      {
+        return notify;
+      });
+  }
 }
 
 void RaceNetworkHandler::HandleRaceResult(
@@ -4137,6 +4198,30 @@ void RaceNetworkHandler::HandleGameCreateClientItem(
   auto& item = raceInstance.GetTracker().AddEventItem(clientContext.characterUid);
   item.position = command.position;
   item.itemType = selectedEgg.deckItemId;
+}
+
+void RaceNetworkHandler::HandleAchievementUpdateProperty(
+  const ClientId clientId,
+  const protocol::AcCmdCRAchievementUpdateProperty& command)
+{
+  const auto& clientContext = GetClientContext(clientId);
+
+  const auto updates = _serverInstance.GetAchievementSystem()
+    .ApplyReportedProperty(
+      clientContext.characterUid,
+      command.achievementEvent,
+      command.propertyValue);
+
+  for (const auto& update : updates)
+  {
+    const auto notify = AchievementSystem::BuildUpdateNotify(update);
+
+    _commandServer.QueueCommand<decltype(notify)>(
+      clientId, [notify]()
+      {
+        return notify;
+      });
+  }
 }
 
 } // namespace server

--- a/src/server/ranch/RanchDirector.cpp
+++ b/src/server/ranch/RanchDirector.cpp
@@ -20,6 +20,7 @@
 #include "server/ranch/RanchDirector.hpp"
 
 #include "server/ServerInstance.hpp"
+#include "server/system/AchievementSystem.hpp"
 #include "server/system/ItemSystem.hpp"
 
 #include <libserver/data/helper/ProtocolHelper.hpp>
@@ -30,6 +31,7 @@
 #include <algorithm>
 #include <cmath>
 #include <ctime>
+#include <optional>
 #include <ranges>
 
 #include <spdlog/spdlog.h>
@@ -63,6 +65,13 @@ constexpr auto FoalMaturityCheckInterval = std::chrono::seconds(60);
 //! records to load before giving up and cancelling the entry.
 constexpr uint32_t MaxEnterRanchDeferAttempts = 2;
 constexpr uint32_t MaxTryBreedingDeferAttempts = 4;
+
+//! Achievement TID standing for an empty key achievement slot.
+constexpr uint16_t UnusedKeyAchievementSlot = 0;
+
+//! Marks the reward of a book grade as claimed. The client only tests the
+//! value against zero, so any non zero value would do.
+constexpr uint32_t ClaimedBookReward = 1;
 
 BreedingMarket::SnapshotOrder ConvertProtocolStallionOrderToSnapshotOrder(
   const protocol::AcCmdCRSearchStallion::StallionOrder order)
@@ -638,6 +647,12 @@ RanchDirector::RanchDirector(ServerInstance& serverInstance)
     [this](ClientId clientId, const auto& command)
     {
       HandleAchievementDetail(clientId, command);
+    });
+
+  _commandServer.RegisterCommandHandler<protocol::AcCmdCRAchievementBookReward>(
+    [this](ClientId clientId, const auto& command)
+    {
+      HandleAchievementBookReward(clientId, command);
     });
 
   _commandServer.RegisterCommandHandler<protocol::AcCmdCRSetKeyAchievement>(
@@ -7462,14 +7477,195 @@ void RanchDirector::HandleAchievementDetail(
   response.characterUid = command.characterUid;
   response.achievementTid = command.achievementTid;
 
-  // TODO: Load actual per-tier progress from persistent data.
-  // For now, send test data so the achievements page renders.
-  response.tierProgress = {10, 5, 2, 0};
+  // The details belong to the profile being looked at, which is not necessarily
+  // the requesting character.
+  const auto characterRecord = _serverInstance.GetDataDirector().GetCharacter(
+    command.characterUid);
+
+  if (characterRecord.IsAvailable())
+  {
+    characterRecord.Immutable(
+      [&response, tid = command.achievementTid](const data::Character& character)
+      {
+        const auto& achievements = character.achievements();
+        const auto entry = std::ranges::find(
+          achievements, tid, &data::Character::AchievementEntry::tid);
+
+        if (entry == achievements.end())
+          return;
+
+        // Leaving the dates at zero is meaningful: the client reads a year of
+        // zero as "tier not earned" and shows its placeholder instead of a date.
+        for (size_t tier = 0; tier < response.tierEarnedDates.size(); ++tier)
+        {
+          response.tierEarnedDates[tier] =
+            protocol::BuildProtocolAchievementDate(entry->tierEarnedAt[tier]);
+        }
+      });
+  }
+  else
+  {
+    spdlog::warn(
+      "Achievement detail requested for unavailable character '{}'",
+      command.characterUid);
+  }
 
   spdlog::debug(
-    "Achievement detail requested by '{}' for TID {}",
+    "Achievement detail requested by '{}' for character '{}' TID {}",
     clientContext.characterUid,
+    command.characterUid,
     command.achievementTid);
+
+  _commandServer.QueueCommand<decltype(response)>(
+    clientId, [response]()
+    {
+      return response;
+    });
+}
+
+void RanchDirector::HandleAchievementBookReward(
+  ClientId clientId,
+  const protocol::AcCmdCRAchievementBookReward& command)
+{
+  const auto& clientContext = GetClientContext(clientId);
+  const auto characterUid = clientContext.characterUid;
+
+  const auto cancel = [this, clientId]()
+  {
+    protocol::AcCmdCRAchievementBookRewardCancel response{};
+    _commandServer.QueueCommand<decltype(response)>(
+      clientId, [response]()
+      {
+        return response;
+      });
+  };
+
+  if (command.bookType < 0
+    or command.bookType >= static_cast<int8_t>(registry::AchievementBookTypeCount))
+  {
+    spdlog::warn(
+      "Character '{}' claimed book reward for out of range book {}",
+      characterUid,
+      command.bookType);
+    cancel();
+    return;
+  }
+
+  if (command.grade < 0
+    or command.grade >= static_cast<int8_t>(registry::AchievementTierCount))
+  {
+    spdlog::warn(
+      "Character '{}' claimed book reward for out of range grade {}",
+      characterUid,
+      command.grade);
+    cancel();
+    return;
+  }
+
+  const auto characterRecord = _serverInstance.GetDataDirector().GetCharacter(
+    characterUid);
+
+  if (not characterRecord.IsAvailable())
+  {
+    cancel();
+    return;
+  }
+
+  const auto grade = static_cast<size_t>(command.grade);
+  const auto& achievementRegistry = _serverInstance.GetAchievementRegistry();
+
+  data::Tid rewardItemTid = data::InvalidTid;
+  auto rewardItemUid = data::InvalidUid;
+
+  characterRecord.Mutable(
+    [&](data::Character& character)
+    {
+      auto& books = character.achievementBooks();
+      auto book = std::ranges::find(
+        books,
+        static_cast<uint8_t>(command.bookType),
+        &data::Character::AchievementBookEntry::bookId);
+
+      // Only the claim state is stored, so the entry appears with the first
+      // claim of a book.
+      if (book == books.end())
+      {
+        books.push_back({.bookId = static_cast<uint8_t>(command.bookType)});
+        book = std::prev(books.end());
+      }
+
+      // The client only offers grades it believes are reached and unclaimed,
+      // but it is the server that decides. The reward of a grade is earned once
+      // every achievement of the book has reached the tier of that grade.
+      const auto completedTiers =
+        _serverInstance.GetAchievementSystem().GetBookCompletedTierCount(
+          character, command.bookType);
+
+      if (command.grade >= static_cast<int8_t>(completedTiers))
+      {
+        spdlog::warn(
+          "Character '{}' claimed grade {} of book {} with {} tiers completed",
+          characterUid,
+          command.grade,
+          command.bookType,
+          completedTiers);
+        return;
+      }
+
+      if (book->tierRewardClaimed[grade] != 0)
+      {
+        spdlog::warn(
+          "Character '{}' claimed grade {} of book {} twice",
+          characterUid,
+          command.grade,
+          command.bookType);
+        return;
+      }
+
+      const auto* const reward = achievementRegistry.GetBookReward(
+        command.bookType,
+        static_cast<uint8_t>(character.parts.modelId()));
+
+      if (reward == nullptr)
+      {
+        spdlog::warn(
+          "No book reward for book {} and character model {}",
+          command.bookType,
+          character.parts.modelId());
+        return;
+      }
+
+      rewardItemTid = reward->itemTids[grade];
+      if (rewardItemTid == data::InvalidTid)
+        return;
+
+      rewardItemUid = _serverInstance.GetItemSystem().AddItem(
+        character, rewardItemTid, 1);
+      if (rewardItemUid == data::InvalidUid)
+        return;
+
+      book->tierRewardClaimed[grade] = ClaimedBookReward;
+    });
+
+  if (rewardItemUid == data::InvalidUid)
+  {
+    cancel();
+    return;
+  }
+
+  protocol::AcCmdCRAchievementBookRewardOK response{};
+  response.bookType = command.bookType;
+  response.grade = command.grade;
+  response.item.uid = rewardItemUid;
+  response.item.tid = rewardItemTid;
+  response.item.count = 1;
+
+  spdlog::info(
+    "Character '{}' claimed grade {} of achievement book {}, item {}",
+    characterUid,
+    command.grade,
+    command.bookType,
+    rewardItemTid);
 
   _commandServer.QueueCommand<decltype(response)>(
     clientId, [response]()
@@ -7508,10 +7704,32 @@ void RanchDirector::HandleSetKeyAchievement(
     return;
   }
 
+  // The slots are freely chosen and need not be earned, and the same
+  // achievement may sit in several of them. The client enforces neither rule,
+  // it only drops a slot whose achievement does not exist, so that is the one
+  // check worth repeating here against a manipulated client.
+  const auto& achievementRegistry = _serverInstance.GetAchievementRegistry();
+  auto keyAchievements = command.keyAchievements;
+
+  for (auto& tid : keyAchievements)
+  {
+    if (tid == UnusedKeyAchievementSlot)
+      continue;
+
+    if (achievementRegistry.GetAchievement(tid) != nullptr)
+      continue;
+
+    spdlog::warn(
+      "Character '{}' set unknown achievement {} as a key achievement",
+      clientContext.characterUid,
+      tid);
+    tid = UnusedKeyAchievementSlot;
+  }
+
   characterRecord.Mutable(
-    [&command](data::Character& character)
+    [&keyAchievements](data::Character& character)
     {
-      character.keyAchievements = command.keyAchievements;
+      character.keyAchievements = keyAchievements;
     });
 
   protocol::AcCmdCRSetKeyAchievementOK response{};
@@ -7527,91 +7745,23 @@ void RanchDirector::HandleAchievementUpdateProperty(
   const protocol::AcCmdCRAchievementUpdateProperty& command)
 {
   const auto& clientContext = GetClientContext(clientId);
-  const auto characterUid = clientContext.characterUid;
 
-  const auto& achievementRegistry =
-    _serverInstance.GetAchievementRegistry();
+  const auto updates = _serverInstance.GetAchievementSystem()
+    .ApplyReportedProperty(
+      clientContext.characterUid,
+      command.achievementEvent,
+      command.propertyValue);
 
-  const auto matchingAchievements =
-    achievementRegistry.GetAchievementsByEvent(command.achievementEvent);
-
-  if (matchingAchievements.empty())
+  for (const auto& update : updates)
   {
-    spdlog::debug(
-      "No achievements registered for event {}",
-      command.achievementEvent);
-    return;
-  }
+    const auto notify = AchievementSystem::BuildUpdateNotify(update);
 
-  const auto characterRecord =
-    _serverInstance.GetDataDirector().GetCharacter(characterUid);
-
-  if (not characterRecord.IsAvailable())
-    return;
-
-  characterRecord.Mutable(
-    [&](data::Character& character)
-    {
-      for (const auto* achievementInfo : matchingAchievements)
+    _commandServer.QueueCommand<decltype(notify)>(
+      clientId, [notify]()
       {
-        // Find or create the achievement entry.
-        data::Character::AchievementEntry* entry = nullptr;
-        for (auto& existing : character.achievements())
-        {
-          if (existing.tid == achievementInfo->tid)
-          {
-            entry = &existing;
-            break;
-          }
-        }
-
-        if (entry == nullptr)
-        {
-          character.achievements().push_back({.tid = achievementInfo->tid,
-            .completed = false,
-            .progress = 0});
-          entry = &character.achievements().back();
-        }
-
-        if (entry->completed)
-          continue;
-
-        // For "TRUE" function achievements, any matching event increments progress.
-        // For specific functions, the client sends the event only when the condition
-        // is met on client side, so we trust the event and increment.
-        entry->progress++;
-
-        if (entry->progress >= achievementInfo->successValue)
-        {
-          entry->completed = true;
-
-          // Award carrots.
-          character.carrots() +=
-            static_cast<int32_t>(achievementInfo->reward);
-
-          spdlog::info(
-            "Achievement {} completed by character '{}' (+{} carrots)",
-            achievementInfo->tid,
-            characterUid,
-            achievementInfo->reward);
-        }
-
-        // Notify the client of the progress update.
-        protocol::AcCmdRCAchievementUpdateNotify notify{};
-        notify.achievementTid = achievementInfo->tid;
-        notify.objectiveProgress.isCompleted = entry->completed;
-        notify.objectiveProgress.progress = entry->progress;
-        notify.objectiveProgress.achievementTier =
-          protocol::ObjectiveProgress::AchievementTier::None;
-        notify.carrotBalance = character.carrots();
-
-        _commandServer.QueueCommand<decltype(notify)>(
-          clientId, [notify]()
-          {
-            return notify;
-          });
-      }
-    });
+        return notify;
+      });
+  }
 }
 
 } // namespace server

--- a/src/server/ranch/RanchDirector.cpp
+++ b/src/server/ranch/RanchDirector.cpp
@@ -23,6 +23,7 @@
 #include "server/system/ItemSystem.hpp"
 
 #include <libserver/data/helper/ProtocolHelper.hpp>
+#include <libserver/network/command/proto/RaceMessageDefinitions.hpp>
 #include <libserver/util/Locale.hpp>
 #include <libserver/util/Util.hpp>
 
@@ -625,6 +626,24 @@ RanchDirector::RanchDirector(ServerInstance& serverInstance)
     [this](ClientId clientId, const auto& command)
     {
       HandleBreedingWishlistDelete(clientId, command);
+    });
+
+  _commandServer.RegisterCommandHandler<protocol::AcCmdCRAchievementUpdateProperty>(
+    [this](ClientId clientId, const auto& command)
+    {
+      HandleAchievementUpdateProperty(clientId, command);
+    });
+
+  _commandServer.RegisterCommandHandler<protocol::AcCmdCRAchievementDetail>(
+    [this](ClientId clientId, const auto& command)
+    {
+      HandleAchievementDetail(clientId, command);
+    });
+
+  _commandServer.RegisterCommandHandler<protocol::AcCmdCRSetKeyAchievement>(
+    [this](ClientId clientId, const auto& command)
+    {
+      HandleSetKeyAchievement(clientId, command);
     });
 }
 
@@ -7430,6 +7449,168 @@ void RanchDirector::HandleBreedingWishlistDelete(
     [response]()
     {
       return response;
+    });
+}
+
+void RanchDirector::HandleAchievementDetail(
+  ClientId clientId,
+  const protocol::AcCmdCRAchievementDetail& command)
+{
+  const auto& clientContext = GetClientContext(clientId);
+
+  protocol::AcCmdCRAchievementDetailOK response{};
+  response.characterUid = command.characterUid;
+  response.achievementTid = command.achievementTid;
+
+  // TODO: Load actual per-tier progress from persistent data.
+  // For now, send test data so the achievements page renders.
+  response.tierProgress = {10, 5, 2, 0};
+
+  spdlog::debug(
+    "Achievement detail requested by '{}' for TID {}",
+    clientContext.characterUid,
+    command.achievementTid);
+
+  _commandServer.QueueCommand<decltype(response)>(
+    clientId, [response]()
+    {
+      return response;
+    });
+}
+
+void RanchDirector::HandleSetKeyAchievement(
+  ClientId clientId,
+  const protocol::AcCmdCRSetKeyAchievement& command)
+{
+  const auto& clientContext = GetClientContext(clientId);
+
+  spdlog::debug(
+    "Set key achievements for '{}': [{}, {}, {}]",
+    clientContext.characterUid,
+    command.keyAchievements[0],
+    command.keyAchievements[1],
+    command.keyAchievements[2]);
+
+  const auto characterRecord = _serverInstance.GetDataDirector().GetCharacter(
+    clientContext.characterUid);
+
+  if (not characterRecord.IsAvailable())
+  {
+    spdlog::warn(
+      "Character '{}' not found for key achievement update",
+      clientContext.characterUid);
+    protocol::AcCmdCRSetKeyAchievementCancel cancel{};
+    _commandServer.QueueCommand<decltype(cancel)>(
+      clientId, [cancel]()
+      {
+        return cancel;
+      });
+    return;
+  }
+
+  characterRecord.Mutable(
+    [&command](data::Character& character)
+    {
+      character.keyAchievements = command.keyAchievements;
+    });
+
+  protocol::AcCmdCRSetKeyAchievementOK response{};
+  _commandServer.QueueCommand<decltype(response)>(
+    clientId, [response]()
+    {
+      return response;
+    });
+}
+
+void RanchDirector::HandleAchievementUpdateProperty(
+  ClientId clientId,
+  const protocol::AcCmdCRAchievementUpdateProperty& command)
+{
+  const auto& clientContext = GetClientContext(clientId);
+  const auto characterUid = clientContext.characterUid;
+
+  const auto& achievementRegistry =
+    _serverInstance.GetAchievementRegistry();
+
+  const auto matchingAchievements =
+    achievementRegistry.GetAchievementsByEvent(command.achievementEvent);
+
+  if (matchingAchievements.empty())
+  {
+    spdlog::debug(
+      "No achievements registered for event {}",
+      command.achievementEvent);
+    return;
+  }
+
+  const auto characterRecord =
+    _serverInstance.GetDataDirector().GetCharacter(characterUid);
+
+  if (not characterRecord.IsAvailable())
+    return;
+
+  characterRecord.Mutable(
+    [&](data::Character& character)
+    {
+      for (const auto* achievementInfo : matchingAchievements)
+      {
+        // Find or create the achievement entry.
+        data::Character::AchievementEntry* entry = nullptr;
+        for (auto& existing : character.achievements())
+        {
+          if (existing.tid == achievementInfo->tid)
+          {
+            entry = &existing;
+            break;
+          }
+        }
+
+        if (entry == nullptr)
+        {
+          character.achievements().push_back({.tid = achievementInfo->tid,
+            .completed = false,
+            .progress = 0});
+          entry = &character.achievements().back();
+        }
+
+        if (entry->completed)
+          continue;
+
+        // For "TRUE" function achievements, any matching event increments progress.
+        // For specific functions, the client sends the event only when the condition
+        // is met on client side, so we trust the event and increment.
+        entry->progress++;
+
+        if (entry->progress >= achievementInfo->successValue)
+        {
+          entry->completed = true;
+
+          // Award carrots.
+          character.carrots() +=
+            static_cast<int32_t>(achievementInfo->reward);
+
+          spdlog::info(
+            "Achievement {} completed by character '{}' (+{} carrots)",
+            achievementInfo->tid,
+            characterUid,
+            achievementInfo->reward);
+        }
+
+        // Notify the client of the progress update.
+        protocol::AcCmdRCAchievementUpdateNotify notify{};
+        notify.achievementTid = achievementInfo->tid;
+        notify.objectiveProgress.isCompleted = entry->completed;
+        notify.objectiveProgress.progress = entry->progress;
+        notify.objectiveProgress.achievementTier =
+          protocol::ObjectiveProgress::AchievementTier::None;
+        notify.carrotBalance = character.carrots();
+
+        _commandServer.QueueCommand<decltype(notify)>(
+          clientId, [notify]()
+          {
+            return notify;
+          });
+      }
     });
 }
 

--- a/src/server/system/AchievementSystem.cpp
+++ b/src/server/system/AchievementSystem.cpp
@@ -1,0 +1,579 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2024 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#include "server/system/AchievementSystem.hpp"
+
+#include "libserver/registry/AchievementRegistry.hpp"
+#include "server/ServerInstance.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <limits>
+#include <optional>
+
+namespace server
+{
+
+namespace
+{
+
+//! Parses the decimal text a property update carries, which is a plain integer
+//! for counters and has two decimal places for distances, times and speeds.
+//! @param scale Factor bringing the value into the unit of the thresholds.
+//! @param text The reported value, at most 16 characters.
+//! @returns The rounded value, or nothing when the text is not a number.
+std::optional<uint32_t> ParseReportedValue(
+  const double scale,
+  const std::string& text)
+{
+  double value = 0.0;
+  const auto* const begin = text.data();
+  const auto* const end = begin + text.size();
+
+  const auto [parsedUntil, error] = std::from_chars(begin, end, value);
+  if (error != std::errc{} or parsedUntil != end)
+    return std::nullopt;
+
+  if (value <= 0.0)
+    return 0u;
+
+  const auto rounded = std::llround(value * scale);
+  if (rounded > std::numeric_limits<uint32_t>::max())
+    return std::numeric_limits<uint32_t>::max();
+
+  return static_cast<uint32_t>(rounded);
+}
+
+//! Event the race result reports under. No client ever sends it.
+constexpr uint16_t RaceResultEvent = 2;
+
+//! Perfect, good and failed landings. The client sorts every landing into at
+//! most one of them, so they add up without counting a jump twice.
+constexpr std::array<uint16_t, 3> JumpEvents = {29, 30, 31};
+
+//! Event carrying how often the racer slid.
+constexpr uint16_t SlidingCountEvent = 26;
+
+//! What a racer did during the race. The client sends no summary at the end,
+//! so the reports made while it ran are the only source.
+struct RaceStatistics
+{
+  //! How often the racer left the ground.
+  uint32_t jumpCount{};
+  //! How often the racer slid.
+  uint32_t slidingCount{};
+};
+
+//! Event a run is broken by when it has to hold within a single login. The
+//! client neither sends it nor names it; the three achievements resetting on it
+//! all ask for races finished within one connection.
+constexpr uint16_t SessionEndEvent = 4;
+
+//! Finds the stored progress of an achievement, creating it on first contact.
+//! @param character The character record.
+//! @param tid The achievement.
+//! @returns The entry, which lives in the character record.
+data::Character::AchievementEntry& FindOrCreateEntry(
+  data::Character& character,
+  const uint16_t tid)
+{
+  auto& achievements = character.achievements();
+  const auto entry = std::ranges::find(
+    achievements, tid, &data::Character::AchievementEntry::tid);
+
+  if (entry != achievements.end())
+    return *entry;
+
+  achievements.push_back({.tid = tid});
+  return achievements.back();
+}
+
+//! Stamps every tier just crossed, pays out its reward and describes the change.
+//! @param characterUid The character, for the log.
+//! @param character The character record, for the carrot balance.
+//! @param info The achievement.
+//! @param entry Its stored progress, already brought up to date.
+//! @param tiersBefore Count of tiers earned before the change.
+//! @returns What to tell the client about this achievement.
+AchievementSystem::ProgressUpdate AwardReachedTiers(
+  const data::Uid characterUid,
+  data::Character& character,
+  const registry::AchievementInfo& info,
+  data::Character::AchievementEntry& entry,
+  const uint8_t tiersBefore)
+{
+  const auto tiersAfter = info.GetReachedTierCount(entry.progress);
+
+  for (uint8_t tier = tiersBefore; tier < tiersAfter; ++tier)
+  {
+    entry.tierEarnedAt[tier] = data::Clock::now();
+    character.carrots() += static_cast<int32_t>(info.rewards[tier]);
+
+    spdlog::info(
+      "Character '{}' reached tier {} of achievement {} (+{} carrots)",
+      characterUid,
+      tier,
+      info.tid,
+      info.rewards[tier]);
+  }
+
+  // A tier was just reached, which is not the same as the achievement being
+  // done. The client marks the reported tier and plays its ceremony only then.
+  const bool reachedTier = tiersAfter > tiersBefore;
+
+  return {
+    .achievementTid = info.tid,
+    .progress = entry.progress,
+    .reachedTier = reachedTier,
+    .tier = reachedTier ? static_cast<uint8_t>(tiersAfter - 1) : uint8_t{},
+    .carrotBalance = character.carrots()};
+}
+
+//! Whether an hour of the day falls into a window, the end being exclusive.
+//! @param hour The hour the race ended in.
+//! @param from First hour of the window.
+//! @param until First hour no longer in the window.
+//! @returns True when the hour is inside.
+bool WithinHours(const uint8_t hour, const uint8_t from, const uint8_t until)
+{
+  return hour >= from and hour < until;
+}
+
+//! Whether a race satisfies a reset condition, so whether the run is broken.
+//! @param function Name of the reset condition.
+//! @param resetEventId Event the reset is judged on.
+//! @param outcome What the race amounted to.
+//! @param supported Set to false when the condition cannot be judged yet.
+//! @returns True when the run is broken and the progress goes back to zero.
+bool RaceOutcomeBreaksRun(
+  const std::string& function,
+  const uint16_t resetEventId,
+  const AchievementSystem::RaceOutcome& outcome,
+  bool& supported)
+{
+  supported = true;
+
+  // A run held within one login is broken by the session ending, not by a race.
+  if (resetEventId == SessionEndEvent)
+    return false;
+
+  // Anything that is not a win breaks the run, including giving up.
+  if (function == "NotWin")
+    return not (outcome.finished and outcome.placement == 1);
+
+  // Losing means reaching the goal behind someone, which giving up is not.
+  if (function == "Lose")
+    return outcome.finished and outcome.placement != 1;
+
+  if (function == "Retire" or function == "RetireOrDisconnect")
+    return not outcome.finished;
+
+  if (function == "GoalIn")
+    return outcome.finished;
+
+  // TeamLose and NotTeamWin need the team result, which is only settled once
+  // every racer has finished.
+  supported = false;
+  return false;
+}
+
+//! Decides whether a race satisfies the named condition. An unlisted condition
+//! never fires, because an achievement handed out wrongly cannot be taken back.
+//! 47 of the 84 race achievements are still missing, in five groups:
+//! - Team result, 11, settled only once every racer has finished: TeamWin,
+//!   TeamPerfectWin, TeamPerfectWinNew, TeamWinTheLast, PerfectWin.
+//! - History across races, 8, needing state that outlives one race: MaxWinStop,
+//!   SerialWin, PainOfLosses, Magic_TripleWin, Revenge, KingOfLosers.
+//! - Course and time, 11: the eight Mastery conditions, GoalInAllMap, WinAllMap.
+//! - Never reported by the client, 12: NoCollisionGoalIn, NoNPCCollision,
+//!   NoPlayerCollisionRanking, NoSpurRanking, UseSpur40, NoSlidingWin,
+//!   GoalInWithSpur, GoalInWithSliding, GoalInWithGliding, StartingWinner,
+//!   ReversalWinner, OtherRetirePlayerCount.
+//! - Modes this server lacks, 5: WinAI, the three Mission conditions,
+//!   CarnivalSuccess.
+//! @param function Name of the condition.
+//! @param info The achievement, for the parameter of the condition.
+//! @param outcome What the race amounted to.
+//! @returns True when the race counts for the achievement.
+bool RaceOutcomeSatisfies(
+  const std::string& function,
+  const registry::AchievementInfo& info,
+  const AchievementSystem::RaceOutcome& outcome,
+  const RaceStatistics& statistics)
+{
+  // Conditions that read what the racer did during the race. The counts come
+  // from the reports of this race, which are cleared when it starts.
+  if (function == "NoJumpGoalIn")
+    return outcome.finished and statistics.jumpCount == 0;
+
+  if (function == "NoJumpWin")
+    return outcome.finished and outcome.placement == 1
+      and statistics.jumpCount == 0;
+
+  if (function == "NoJumpRanking")
+    return outcome.finished
+      and info.functionValue != 0
+      and outcome.placement <= info.functionValue
+      and statistics.jumpCount == 0;
+
+  if (function == "Sliding20")
+    return outcome.finished and statistics.slidingCount >= 20;
+
+  if (function == "GoalIn")
+    return outcome.finished;
+
+  if (function == "Retire")
+    return not outcome.finished;
+
+  if (function == "Win" or function == "MyFirstWin")
+    return outcome.finished and outcome.placement == 1;
+
+  if (function == "GoalInRanking")
+    return outcome.finished
+      and info.functionValue != 0
+      and outcome.placement <= info.functionValue;
+
+  if (function == "Playing20Races")
+    return true;
+
+  if (function == "GoalIn_8h_13h")
+    return outcome.finished and WithinHours(outcome.hourOfDay, 8, 13);
+
+  if (function == "GoalIn_14h_16h")
+    return outcome.finished and WithinHours(outcome.hourOfDay, 14, 16);
+
+  if (function == "GoalIn_16h_18h")
+    return outcome.finished and WithinHours(outcome.hourOfDay, 16, 18);
+
+  if (function == "GoalIn_19h_22h")
+    return outcome.finished and WithinHours(outcome.hourOfDay, 19, 22);
+
+  return false;
+}
+
+} // namespace
+
+AchievementSystem::AchievementSystem(ServerInstance& serverInstance)
+  : _serverInstance(serverInstance)
+{
+  // Empty.
+}
+
+protocol::AcCmdRCAchievementUpdateNotify AchievementSystem::BuildUpdateNotify(
+  const ProgressUpdate& update)
+{
+  protocol::AcCmdRCAchievementUpdateNotify notify{};
+  notify.achievementTid = update.achievementTid;
+  notify.objectiveProgress.isCompleted = update.reachedTier;
+  notify.objectiveProgress.progress = update.progress;
+  notify.objectiveProgress.achievementTier = update.reachedTier
+    ? static_cast<protocol::ObjectiveProgress::AchievementTier>(update.tier)
+    : protocol::ObjectiveProgress::AchievementTier::None;
+  notify.carrotBalance = update.carrotBalance;
+
+  return notify;
+}
+
+std::vector<AchievementSystem::ProgressUpdate>
+AchievementSystem::ApplyReportedProperty(
+  const data::Uid characterUid,
+  const uint16_t eventId,
+  const std::string& propertyValue)
+{
+  std::vector<ProgressUpdate> updates;
+
+  const auto& achievementRegistry = _serverInstance.GetAchievementRegistry();
+
+  const auto reported = ParseReportedValue(
+    achievementRegistry.GetReportedValueScale(eventId), propertyValue);
+  if (not reported.has_value() and not propertyValue.empty())
+  {
+    // An empty value is normal, anything else is a gap in our reading of it.
+    spdlog::warn(
+      "Unparsable achievement property value '{}' on event {}",
+      propertyValue,
+      eventId);
+  }
+
+  // Kept even for an event no achievement listens to, because the statistics of
+  // a race are read back from here and count the good and failed jumps, which
+  // nothing is triggered by.
+  uint32_t lastReportedValue = 0;
+  {
+    const std::scoped_lock lock(_reportedValuesMutex);
+    auto& reportedValues = _reportedValues[characterUid];
+    lastReportedValue = reportedValues[eventId];
+
+    if (reported.has_value())
+      reportedValues[eventId] = *reported;
+  }
+
+  const auto matchingAchievements =
+    achievementRegistry.GetAchievementsByEvent(eventId);
+
+  if (matchingAchievements.empty())
+    return updates;
+
+  const auto characterRecord =
+    _serverInstance.GetDataDirector().GetCharacter(characterUid);
+
+  if (not characterRecord.IsAvailable())
+    return updates;
+
+  characterRecord.Mutable(
+    [&](data::Character& character)
+    {
+      for (const auto* const achievementInfo : matchingAchievements)
+      {
+        if (achievementInfo->conditionKind == registry::ConditionKind::Never)
+          continue;
+
+        // Without a value only a plain counter can step, a record or a total
+        // would be fabricating a result.
+        if (not reported.has_value()
+          and achievementInfo->compareType != registry::CompareType::Count)
+          continue;
+
+        auto& entry = FindOrCreateEntry(character, achievementInfo->tid);
+
+        const auto tiersBefore = GetEarnedTierCount(entry);
+        if (tiersBefore >= entry.tierEarnedAt.size())
+          continue;
+
+        if (achievementInfo->IsGated())
+        {
+          // Count the crossings of the bar, not every step above it.
+          if (not reported.has_value()
+            or not achievementInfo->PassesBar(*reported)
+            or achievementInfo->PassesBar(lastReportedValue))
+          {
+            continue;
+          }
+
+          entry.progress += 1;
+        }
+        else
+        {
+          entry.progress = reported.has_value()
+            ? achievementInfo->CombineProgress(
+                entry.progress, *reported, lastReportedValue)
+            : entry.progress + 1;
+        }
+
+        updates.push_back(AwardReachedTiers(
+          characterUid, character, *achievementInfo, entry, tiersBefore));
+      }
+    });
+
+  return updates;
+}
+
+std::vector<AchievementSystem::ProgressUpdate>
+AchievementSystem::ApplyRaceOutcome(
+  const data::Uid characterUid,
+  const RaceOutcome& outcome)
+{
+  std::vector<ProgressUpdate> updates;
+
+  // Cleared when the race started, so what is left belongs to this race.
+  RaceStatistics statistics;
+  {
+    const std::scoped_lock lock(_reportedValuesMutex);
+    const auto reported = _reportedValues.find(characterUid);
+    if (reported != _reportedValues.end())
+    {
+      for (const auto event : JumpEvents)
+      {
+        const auto value = reported->second.find(event);
+        if (value != reported->second.end())
+          statistics.jumpCount += value->second;
+      }
+
+      const auto sliding = reported->second.find(SlidingCountEvent);
+      if (sliding != reported->second.end())
+        statistics.slidingCount = sliding->second;
+    }
+  }
+
+  const auto& achievementRegistry = _serverInstance.GetAchievementRegistry();
+  const auto raceAchievements =
+    achievementRegistry.GetAchievementsByEvent(RaceResultEvent);
+
+  const auto characterRecord =
+    _serverInstance.GetDataDirector().GetCharacter(characterUid);
+
+  if (not characterRecord.IsAvailable())
+    return updates;
+
+  characterRecord.Mutable(
+    [&](data::Character& character)
+    {
+      for (const auto* const achievementInfo : raceAchievements)
+      {
+        if (not achievementInfo->CountsInMode(outcome.mode))
+          continue;
+
+        if (outcome.racerCount < achievementInfo->numPlayer)
+          continue;
+
+        // A reset that cannot be judged skips the achievement, since without it
+        // "three wins in a row" would count as "three wins".
+        bool resetSupported = true;
+        bool runBroken = false;
+        if (not achievementInfo->resetFunction.empty())
+        {
+          runBroken = RaceOutcomeBreaksRun(
+            achievementInfo->resetFunction,
+            achievementInfo->resetEventId,
+            outcome,
+            resetSupported);
+
+          if (not resetSupported)
+            continue;
+        }
+
+        const bool satisfied = RaceOutcomeSatisfies(
+          achievementInfo->function, *achievementInfo, outcome, statistics);
+
+        if (not satisfied and not runBroken)
+          continue;
+
+        auto& entry = FindOrCreateEntry(character, achievementInfo->tid);
+
+        const auto tiersBefore = GetEarnedTierCount(entry);
+        if (tiersBefore >= entry.tierEarnedAt.size())
+          continue;
+
+        if (runBroken)
+        {
+          // The run starts over. Earned tiers stay, only the count is lost.
+          entry.progress = 0;
+          continue;
+        }
+
+        // A race counts once, so every one of these is a plain step.
+        entry.progress += 1;
+
+        updates.push_back(AwardReachedTiers(
+          characterUid, character, *achievementInfo, entry, tiersBefore));
+      }
+    });
+
+  return updates;
+}
+
+void AchievementSystem::ApplySessionEnd(const data::Uid characterUid)
+{
+  const auto characterRecord =
+    _serverInstance.GetDataDirector().GetCharacter(characterUid);
+
+  if (not characterRecord.IsAvailable())
+    return;
+
+  characterRecord.Mutable(
+    [&](data::Character& character)
+    {
+      const auto& achievementRegistry =
+        _serverInstance.GetAchievementRegistry();
+
+      for (auto& entry : character.achievements())
+      {
+        const auto* const info = achievementRegistry.GetAchievement(entry.tid);
+        if (info == nullptr or info->resetEventId != SessionEndEvent)
+          continue;
+
+        // Earned tiers stay, only the run towards the next one is lost.
+        entry.progress = 0;
+      }
+    });
+}
+
+void AchievementSystem::ForgetReportedValues(const data::Uid characterUid)
+{
+  const std::scoped_lock lock(_reportedValuesMutex);
+  _reportedValues.erase(characterUid);
+}
+
+uint8_t AchievementSystem::GetEarnedTierCount(
+  const data::Character::AchievementEntry& entry)
+{
+  uint8_t earned = 0;
+  for (const auto earnedAt : entry.tierEarnedAt)
+  {
+    if (earnedAt == data::Clock::time_point{})
+      break;
+
+    ++earned;
+  }
+
+  return earned;
+}
+
+uint8_t AchievementSystem::GetBookCompletedTierCount(
+  const data::Character& character,
+  const int8_t bookType) const
+{
+  const auto bookAchievements =
+    _serverInstance.GetAchievementRegistry().GetAchievementsByBook(bookType);
+
+  if (bookAchievements.empty())
+    return 0;
+
+  const auto& achievements = character.achievements();
+
+  // Tiers are earned in order, so the count of tiers reached by the weakest
+  // achievement of the book is how far the book itself has come.
+  uint8_t completedTiers = registry::AchievementTierCount;
+  for (const auto* const bookAchievement : bookAchievements)
+  {
+    const auto entry = std::ranges::find(
+      achievements,
+      bookAchievement->tid,
+      &data::Character::AchievementEntry::tid);
+
+    if (entry == achievements.end())
+      return 0;
+
+    completedTiers = std::min(completedTiers, GetEarnedTierCount(*entry));
+    if (completedTiers == 0)
+      return 0;
+  }
+
+  return completedTiers;
+}
+
+uint8_t AchievementSystem::GetBookGrade(
+  const data::Character& character,
+  const int8_t bookType) const
+{
+  // The grade is the index of the highest earned tier, not their count. The
+  // client picks the book icon by indexing a table of four with it and has no
+  // icon for "no grade", so a book without an earned tier still reports bronze.
+  const auto completedTiers = GetBookCompletedTierCount(character, bookType);
+  if (completedTiers == 0)
+    return 0;
+
+  return static_cast<uint8_t>(completedTiers - 1);
+}
+
+} // namespace server


### PR DESCRIPTION
Implements the achievement system against the data the client ships.

Relates to #111.

What it does

- Reads the achievements out of the client data into a registry, with their
  four tiers, thresholds and rewards
- Stores the moment each tier was earned, so the tier, its date and the book
  grade are derived instead of being kept in sync separately
- Handles progress reports on the ranch and on the race server, since the
  client closes the ranch connection while it races
- Derives the achievement books and their grades, and grants the grade reward
  once, with the server deciding whether it was earned
- Evaluates the conditions that the race result can answer

Not (yet) in this PR

- The remaining race conditions, listed by group in `AchievementSystem.cpp`:
  team result, history across races, course times, conditions the client never
  reports, and modes server lacks
- Achievement events outside of races: breeding, horse care, levels, magic
  and social
- The per racer score the client adds up to pick the winning team


<img width="1906" height="995" alt="image" src="https://github.com/user-attachments/assets/f073a807-1585-45b4-8e7d-abf00486ea27" />
<img width="995" height="689" alt="image" src="https://github.com/user-attachments/assets/3ceee2a0-3622-486d-a15e-7e6167e20559" />
