### PR TITLE
Fix/Clear registry on read config

### DIFF
--- a/include/libserver/registry/BreedingRegistry.hpp
+++ b/include/libserver/registry/BreedingRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef BREEDINGREGISTRY_HPP
 #define BREEDINGREGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <cstdint>
 #include <filesystem>
 #include <unordered_map>
@@ -109,10 +111,11 @@ struct BreedingBonusEntry
   int32_t ratioBig{0};
 };
 
-class BreedingRegistry
+class BreedingRegistry : public Registry
 {
 public:
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   //! Returns the probability entry for the given cumulative money spent.
   //! Finds the first entry whose moneySpent >= the given value, or the last entry.

--- a/include/libserver/registry/CharacterRegistry.hpp
+++ b/include/libserver/registry/CharacterRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef CHARACTERREGISTRY_HPP
 #define CHARACTERREGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <cstdint>
 #include <filesystem>
 #include <optional>
@@ -36,10 +38,11 @@ struct CharacterLevelInfo
   uint32_t expRequired{};
 };
 
-class CharacterRegistry
+class CharacterRegistry : public Registry
 {
 public:
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   //! Returns the level info for a given level, or nullopt if not found.
   [[nodiscard]] std::optional<CharacterLevelInfo> GetLevelInfo(uint32_t level) const;

--- a/include/libserver/registry/CourseRegistry.hpp
+++ b/include/libserver/registry/CourseRegistry.hpp
@@ -21,6 +21,7 @@
 #define COURSEREGISTRY_HPP
 
 #include "libserver/network/command/proto/CommonStructureDefinitions.hpp"
+#include "libserver/registry/Registry.hpp"
 #include "libserver/registry/RegistryDefinitions.hpp"
 
 #include <array>
@@ -121,12 +122,13 @@ struct Course
 
 };
 
-class CourseRegistry
+class CourseRegistry : public Registry
 {
 public:
   CourseRegistry();
 
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   [[nodiscard]] const Course::GameModeInfo& GetCourseGameModeInfo(
     GameModeId type) const;

--- a/include/libserver/registry/HorseRegistry.hpp
+++ b/include/libserver/registry/HorseRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef HORSEREGISTRY_HPP
 #define HORSEREGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <array>
 #include <filesystem>
 #include <random>
@@ -190,12 +192,13 @@ struct ShapeInheritance
 };
 
 
-class HorseRegistry
+class HorseRegistry : public Registry
 {
 public:
   HorseRegistry();
 
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   static void BuildDefaultHorse(
     data::Horse& horse,

--- a/include/libserver/registry/HousingRegistry.hpp
+++ b/include/libserver/registry/HousingRegistry.hpp
@@ -21,6 +21,7 @@
 #define HOUSINGREGISTRY_HPP
 
 #include "libserver/data/DataDefinitions.hpp"
+#include "libserver/registry/Registry.hpp"
 
 #include <chrono>
 #include <filesystem>
@@ -119,10 +120,11 @@ struct HousingSetInfo
   uint32_t regularBonusPercent{};
 };
 
-class HousingRegistry final
+class HousingRegistry final : public Registry
 {
 public:
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   //! @param housingId Housing ID.
   //! @returns The housing, or nullptr if no such ID is configured.

--- a/include/libserver/registry/ItemRegistry.hpp
+++ b/include/libserver/registry/ItemRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef ITEMREGISTRY_HPP
 #define ITEMREGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <cstdint>
 #include <filesystem>
 #include <optional>
@@ -218,10 +220,12 @@ struct SetItemInfo
   uint32_t equipEffectValue{};
 };
 
-class ItemRegistry
+class ItemRegistry : public Registry
 {
 public:
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
+
   [[nodiscard]] std::optional<Item> GetItem(uint32_t tid);
   [[nodiscard]] std::unordered_map<uint32_t, Item> GetItems();
   [[nodiscard]] std::optional<Package> GetPackage(uint32_t packageId);

--- a/include/libserver/registry/MagicRegistry.hpp
+++ b/include/libserver/registry/MagicRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef MAGICREGISTRY_HPP
 #define MAGICREGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <array>
 #include <cstdint>
 #include <filesystem>
@@ -117,12 +119,13 @@ struct Magic
   };
 };
 
-class MagicRegistry
+class MagicRegistry : public Registry
 {
 public:
   MagicRegistry() = default;
 
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   [[nodiscard]] const Magic::SlotInfo& GetSlotInfo(uint32_t type) const;
   [[nodiscard]] const Magic::SlotInfo& GetSlotInfoByEffectId(uint32_t effectId) const;

--- a/include/libserver/registry/PetRegistry.hpp
+++ b/include/libserver/registry/PetRegistry.hpp
@@ -21,6 +21,7 @@
 #define PETREGISTRY_HPP
 
 #include "libserver/data/DataDefinitions.hpp"
+#include "libserver/registry/Registry.hpp"
 #include "libserver/registry/RegistryDefinitions.hpp"
 
 #include <filesystem>
@@ -52,10 +53,11 @@ struct PetInfo
   uint32_t petId{};
 };
 
-class PetRegistry final
+class PetRegistry final : public Registry
 {
 public:
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   EggInfo GetEggInfo(data::Tid eggItemTid);
   EggInfo GetEggInfoByDeckId(data::Tid deckItemId);

--- a/include/libserver/registry/QuestRegistry.hpp
+++ b/include/libserver/registry/QuestRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef QUEST_REGISTRY_HPP
 #define QUEST_REGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <cstdint>
 #include <filesystem>
 #include <optional>
@@ -153,10 +155,12 @@ struct Quest
   uint32_t rewardPoint{};
 };
 
-class QuestRegistry
+class QuestRegistry : public Registry
 {
 public:
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
+
   [[nodiscard]] std::optional<Quest> GetQuest(uint32_t tid) const;
   [[nodiscard]] std::optional<QuestReward> GetQuestReward(uint32_t id) const;
   [[nodiscard]] std::optional<QuestRewardPoint> GetQuestRewardPoint(uint32_t point) const;

--- a/include/libserver/registry/Registry.hpp
+++ b/include/libserver/registry/Registry.hpp
@@ -1,0 +1,43 @@
+/**
+ * Alicia Server - dedicated server software
+ * Copyright (C) 2026 Story Of Alicia
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef REGISTRY_HPP
+#define REGISTRY_HPP
+
+#include <filesystem>
+
+namespace server::registry
+{
+
+class Registry
+{
+public:
+  virtual ~Registry() = default;
+
+  //! Reads and parses configuration from the specified path.
+  //! @param configPath Path to the configuration file or directory.
+  virtual void ReadConfig(const std::filesystem::path& configPath) = 0;
+
+  //! Clears all loaded registry data and resets state.
+  virtual void Clear() = 0;
+};
+
+} // namespace server::registry
+
+#endif // REGISTRY_HPP

--- a/include/libserver/registry/SpeedRegistry.hpp
+++ b/include/libserver/registry/SpeedRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef SPEEDREGISTRY_HPP
 #define SPEEDREGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <cstdint>
 #include <filesystem>
 #include <unordered_map>
@@ -42,10 +44,11 @@ struct TeamSpurGaugeInfo
   uint32_t goodTiming{};
 };
 
-class SpeedRegistry
+class SpeedRegistry : public Registry
 {
 public:
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   //! Returns the TeamSpurGaugeInfo for a given racer count.
   //! @throws std::runtime_error if racerCount is not found in the registry.

--- a/include/libserver/registry/SystemContentRegistry.hpp
+++ b/include/libserver/registry/SystemContentRegistry.hpp
@@ -20,6 +20,8 @@
 #ifndef SYSTEMCONTENTREGISTRY_HPP
 #define SYSTEMCONTENTREGISTRY_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <filesystem>
 #include <mutex>
 #include <string>
@@ -29,7 +31,7 @@
 namespace server::registry
 {
 
-class SystemContentRegistry
+class SystemContentRegistry : public Registry
 {
 public:
   struct SystemEntry
@@ -40,11 +42,8 @@ public:
     std::string description{};
   };
 
-  /**
-   * Reads the system configuration from a YAML file.
-   * @param configPath Path to the system.yaml file.
-   */
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   /**
    * Saves the current system configuration back to the YAML file.

--- a/include/server/system/ModerationSystem.hpp
+++ b/include/server/system/ModerationSystem.hpp
@@ -20,6 +20,8 @@
 #ifndef MODERATIONSYSTEM_HPP
 #define MODERATIONSYSTEM_HPP
 
+#include <libserver/registry/Registry.hpp>
+
 #include <filesystem>
 #include <regex>
 #include <string>
@@ -28,7 +30,7 @@
 namespace server
 {
 
-class ModerationSystem
+class ModerationSystem : public registry::Registry
 {
 public:
   struct Verdict
@@ -37,7 +39,8 @@ public:
     bool isPrevented = false;
   };
 
-  void ReadConfig(const std::filesystem::path& configPath);
+  void ReadConfig(const std::filesystem::path& configPath) override;
+  void Clear() override;
 
   //! Moderates an input message and presents a verdict.
   //! @param input Message to validate.

--- a/src/libserver/registry/BreedingRegistry.cpp
+++ b/src/libserver/registry/BreedingRegistry.cpp
@@ -52,11 +52,30 @@ void ReadFailureCardTable(const YAML::Node& node, FailureCardTable& table)
 
 } // anon namespace
 
+void BreedingRegistry::Clear()
+{
+  _failureCardProbs.clear();
+  _normalCard = {};
+  _chanceCard = {};
+  _params = {};
+  _gradeProbabilities.clear();
+  _smallGradeBand = {};
+  _bigGradeBand = {};
+  _bonusEntries.clear();
+}
+
 void BreedingRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
   const auto root = YAML::LoadFile(configPath.string());
   const auto breeding = root["breeding"];
+  if (not breeding)
+    throw std::runtime_error("Missing breeding section");
+
   const auto failureCards = breeding["failureCards"];
+  if (not failureCards)
+    throw std::runtime_error("Missing failureCards section");
+
+  Clear();
 
   for (const auto& probNode : failureCards["probabilities"])
   {

--- a/src/libserver/registry/CharacterRegistry.cpp
+++ b/src/libserver/registry/CharacterRegistry.cpp
@@ -28,6 +28,11 @@
 namespace server::registry
 {
 
+void CharacterRegistry::Clear()
+{
+  _levelInfo.clear();
+}
+
 void CharacterRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
   const auto root = YAML::LoadFile(configPath.string());
@@ -44,7 +49,7 @@ void CharacterRegistry::ReadConfig(const std::filesystem::path& configPath)
   if (not collectionSection)
     throw std::runtime_error("Missing collection section");
 
-  _levelInfo.clear();
+  Clear();
 
   for (const auto& entry : collectionSection)
   {

--- a/src/libserver/registry/CourseRegistry.cpp
+++ b/src/libserver/registry/CourseRegistry.cpp
@@ -126,6 +126,14 @@ CourseRegistry::CourseRegistry()
 {
 }
 
+void CourseRegistry::Clear()
+{
+  _gameModeInfo.clear();
+  _mapBlockInfo.clear();
+  _itemDeckInfo.clear();
+  _deckItemInfo.clear();
+}
+
 void CourseRegistry::ReadConfig(
   const std::filesystem::path& configPath)
 {
@@ -135,40 +143,38 @@ void CourseRegistry::ReadConfig(
   if (not coursesSection)
     throw std::runtime_error("Missing courses section");
 
+  const auto gameModeInfosSection = coursesSection["gameModeInfo"];
+  if (not gameModeInfosSection)
+    throw std::runtime_error("Missing gameModes section");
+
+  const auto gameModesCollection = gameModeInfosSection["collection"];
+  if (not gameModesCollection)
+    throw std::runtime_error("Missing collection section");
+
+  const auto mapBlockInfosSection = coursesSection["mapBlockInfo"];
+  if (not mapBlockInfosSection)
+    throw std::runtime_error("Missing gameModes section");
+
+  const auto mapBlocksCollection = mapBlockInfosSection["collection"];
+  if (not mapBlocksCollection)
+    throw std::runtime_error("Missing collection section");
+
+  Clear();
+
   // Game modes
+  for (const auto& gameModeInfoSection : gameModesCollection)
   {
-    const auto gameModeInfosSection = coursesSection["gameModeInfo"];
-    if (not gameModeInfosSection)
-      throw std::runtime_error("Missing gameModes section");
-
-    const auto collection = gameModeInfosSection["collection"];
-    if (not collection)
-      throw std::runtime_error("Missing collection section");
-
-    for (const auto& gameModeInfoSection : collection)
-    {
-      Course::GameModeInfo gameMode;
-      const auto type = ReadGameModeInfo(gameModeInfoSection, gameMode);
-      _gameModeInfo.emplace(type, gameMode);
-    }
+    Course::GameModeInfo gameMode;
+    const auto type = ReadGameModeInfo(gameModeInfoSection, gameMode);
+    _gameModeInfo.emplace(type, gameMode);
   }
 
   // Map blocks
+  for (const auto& mapBlockInfoSection : mapBlocksCollection)
   {
-    const auto mapBlockInfosSection = coursesSection["mapBlockInfo"];
-    if (not mapBlockInfosSection)
-      throw std::runtime_error("Missing gameModes section");
-
-    const auto collection = mapBlockInfosSection["collection"];
-    if (not collection)
-      throw std::runtime_error("Missing collection section");
-
-    for (const auto& mapBlockInfoSection : collection)
-    {
-      Course::MapBlockInfo mapBlock;
-      const auto id = ReadMapBlockInfo(mapBlockInfoSection, mapBlock);
-      _mapBlockInfo.emplace(id, mapBlock);
-    }
+    Course::MapBlockInfo mapBlock;
+    const auto id = ReadMapBlockInfo(mapBlockInfoSection, mapBlock);
+    _mapBlockInfo.emplace(id, mapBlock);
   }
 
   // Deck items

--- a/src/libserver/registry/HorseRegistry.cpp
+++ b/src/libserver/registry/HorseRegistry.cpp
@@ -68,6 +68,35 @@ HorseRegistry::HorseRegistry()
 {
 }
 
+void HorseRegistry::Clear()
+{
+  _colorGroups.clear();
+  _coats.clear();
+  _faces.clear();
+  _manes.clear();
+  _tails.clear();
+  _possibleCoats.clear();
+  _possibleFaces.clear();
+  _facesByType.clear();
+  _possibleManes.clear();
+  _possibleTails.clear();
+  _potentialGrowth.clear();
+  _potentialLevels.clear();
+  _potentials.clear();
+  _potentialTypes.clear();
+  _masteryParams = {};
+  _masteryRewards.clear();
+  _tendencies.clear();
+  _groupForces.clear();
+  _levelUpPoints = {};
+  _grades.clear();
+  _emblems.clear();
+  _emblemRatios.clear();
+  maneTailColorGroups.clear();
+  _manesByColorAndShape.clear();
+  _tailsByColorAndShape.clear();
+}
+
 void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
   // Horse tables are split across category files under the config directory.
@@ -81,7 +110,8 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
       root[entry.first.as<std::string>()] = entry.second;
   }
 
-  _colorGroups.clear();
+  Clear();
+
   for (const auto& node : root["colorGroups"])
   {
     std::vector<Color> colors;
@@ -94,8 +124,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     _colorGroups.push_back(std::move(colors));
   }
 
-  _coats.clear();
-  _possibleCoats.clear();
   for (const auto& node : root["coats"])
   {
     const auto tid = node["tid"].as<data::Tid>();
@@ -110,9 +138,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     _possibleCoats.emplace_back(tid);
   }
 
-  _faces.clear();
-  _possibleFaces.clear();
-  _facesByType.clear();
   for (const auto& node : root["faces"])
   {
     const auto tid = node["tid"].as<data::Tid>();
@@ -125,8 +150,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     _facesByType[type].emplace_back(tid);
   }
 
-  _manes.clear();
-  _possibleManes.clear();
   for (const auto& node : root["manes"])
   {
     const auto tid = node["tid"].as<data::Tid>();
@@ -141,8 +164,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     _possibleManes.emplace_back(tid);
   }
 
-  _tails.clear();
-  _possibleTails.clear();
   for (const auto& node : root["tails"])
   {
     const auto tid = node["tid"].as<data::Tid>();
@@ -157,7 +178,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     _possibleTails.emplace_back(tid);
   }
 
-  _potentialGrowth.clear();
   for (const auto& node : root["potentialGrowth"])
   {
     const auto type = node["type"].as<uint32_t>();
@@ -170,7 +190,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     _potentialGrowth[type] = pg;
   }
 
-  _potentialLevels.clear();
   for (const auto& node : root["potentialLevels"])
   {
     _potentialLevels.emplace_back(PotentialLevel{
@@ -179,8 +198,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     });
   }
 
-  _potentials.clear();
-  _potentialTypes.clear();
   for (const auto& node : root["potentials"])
   {
     const auto type = node["type"].as<uint32_t>();
@@ -203,7 +220,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     };
   }
 
-  _masteryRewards.clear();
   for (const auto& node : root["mastery"]["rewards"])
   {
     _masteryRewards.push_back(MasteryReward{
@@ -213,7 +229,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     });
   }
 
-  _tendencies.clear();
   for (const auto& node : root["tendencies"])
   {
     const auto tendency = node["tendency"].as<uint32_t>();
@@ -224,7 +239,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     };
   }
 
-  _groupForces.clear();
   for (const auto& node : root["groupForces"])
   {
     const auto id = node["id"].as<uint32_t>();
@@ -255,7 +269,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     };
   }
 
-  _grades.clear();
   for (const auto& node : root["grades"])
   {
     const auto grade = node["grade"].as<uint32_t>();
@@ -266,7 +279,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     };
   }
 
-  _emblems.clear();
   for (const auto& node : root["emblems"])
   {
     const auto id = node["id"].as<uint32_t>();
@@ -276,7 +288,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
     };
   }
 
-  _emblemRatios.clear();
   for (const auto& node : root["emblemRatios"])
   {
     const auto odds = node["odds"].as<uint32_t>();
@@ -285,9 +296,6 @@ void HorseRegistry::ReadConfig(const std::filesystem::path& configPath)
       .ratio = node["ratio"].as<int32_t>(),
     };
   }
-
-  _manesByColorAndShape.clear();
-  _tailsByColorAndShape.clear();
 
   for (const auto& [tid, mane] : _manes)
   {

--- a/src/libserver/registry/HousingRegistry.cpp
+++ b/src/libserver/registry/HousingRegistry.cpp
@@ -76,16 +76,25 @@ void ReadHousingSetInfo(const YAML::Node& node, HousingSetInfo& info)
 
 } // anon namespace
 
-void HousingRegistry::ReadConfig(const std::filesystem::path& configPath)
+void HousingRegistry::Clear()
 {
-  const auto root = YAML::LoadFile(configPath.string());
-
   _housing.clear();
   _housingById.clear();
   _sets.clear();
   _ranchLevels.clear();
+}
 
-  for (const auto& node : root["housing"])
+void HousingRegistry::ReadConfig(const std::filesystem::path& configPath)
+{
+  const auto root = YAML::LoadFile(configPath.string());
+
+  const auto housingSection = root["housing"];
+  if (not housingSection)
+    throw std::runtime_error("Missing housing section");
+
+  Clear();
+
+  for (const auto& node : housingSection)
   {
     HousingInfo info;
     ReadHousingInfo(node, info);

--- a/src/libserver/registry/ItemRegistry.cpp
+++ b/src/libserver/registry/ItemRegistry.cpp
@@ -148,6 +148,13 @@ void ReadShopInfo(
 
 } // anon namespace
 
+void ItemRegistry::Clear()
+{
+  _items.clear();
+  _packages.clear();
+  _sets.clear();
+}
+
 void ItemRegistry::ReadConfig(const std::filesystem::path& configDir)
 {
   const auto itemsRoot = YAML::LoadFile((configDir / "items.yaml").string());
@@ -161,7 +168,7 @@ void ItemRegistry::ReadConfig(const std::filesystem::path& configDir)
   if (not packagesCollectionSection)
     throw std::runtime_error("Missing collection section in packages.yaml");
 
-  _items.clear();
+  Clear();
 
   for (const auto& itemSection : collectionSection)
   {
@@ -243,7 +250,6 @@ void ItemRegistry::ReadConfig(const std::filesystem::path& configDir)
   }
 
   // Load mount-equipment set bonuses. Optional: absence leaves the feature inert.
-  _sets.clear();
   const auto setsPath = configDir / "sets.yaml";
   if (std::filesystem::exists(setsPath))
   {

--- a/src/libserver/registry/MagicRegistry.cpp
+++ b/src/libserver/registry/MagicRegistry.cpp
@@ -77,6 +77,21 @@ uint32_t ReadSlotInfo(const YAML::Node& section, Magic::SlotInfo& slot)
 
 } // anonymous namespace
 
+void MagicRegistry::Clear()
+{
+  _slotInfo.clear();
+  _soloPool.clear();
+  _teamPool.clear();
+  _statScalings.clear();
+  for (auto& weights : _soloPositionWeights)
+    weights.clear();
+  for (auto& weights : _teamPositionWeights)
+    weights.clear();
+  _regenInfo = {};
+  _setBonusInfo = {};
+  _baseCritChanceBp = 500;
+}
+
 void MagicRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
   const auto root = YAML::LoadFile(configPath.string());
@@ -85,22 +100,22 @@ void MagicRegistry::ReadConfig(const std::filesystem::path& configPath)
   if (not magicSection)
     throw std::runtime_error("Missing magic section");
 
+  const auto slotSection = magicSection["slotInfo"];
+  if (not slotSection)
+    throw std::runtime_error("Missing magic slotInfo section");
+
+  const auto collection = slotSection["collection"];
+  if (not collection)
+    throw std::runtime_error("Missing magic slotInfo collection");
+
+  Clear();
+
   // Slot info
+  for (const auto& entry : collection)
   {
-    const auto slotSection = magicSection["slotInfo"];
-    if (not slotSection)
-      throw std::runtime_error("Missing magic slotInfo section");
-
-    const auto collection = slotSection["collection"];
-    if (not collection)
-      throw std::runtime_error("Missing magic slotInfo collection");
-
-    for (const auto& entry : collection)
-    {
-      Magic::SlotInfo slot;
-      const auto type = ReadSlotInfo(entry, slot);
-      _slotInfo.emplace(type, std::move(slot));
-    }
+    Magic::SlotInfo slot;
+    const auto type = ReadSlotInfo(entry, slot);
+    _slotInfo.emplace(type, std::move(slot));
   }
 
   // Pre-build the pick pools and positional weights so RandomMagicItem never has to filter at runtime.

--- a/src/libserver/registry/PetRegistry.cpp
+++ b/src/libserver/registry/PetRegistry.cpp
@@ -72,14 +72,35 @@ data::Tid ReadPetInfo(
 
 } // anon namespace
 
+void PetRegistry::Clear()
+{
+  _eggs.clear();
+  _pets.clear();
+}
+
 void PetRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
   const auto root = YAML::LoadFile(configPath.string());
 
   const auto petsSection = root["pets"];
-  const auto eggsSection = petsSection["eggs"];
+  if (not petsSection)
+    throw std::runtime_error("Missing pets section in pets.yaml");
 
-  for (const auto& eggSection : eggsSection["collection"])
+  const auto eggsSection = petsSection["eggs"];
+  if (not eggsSection)
+    throw std::runtime_error("Missing eggs section in pets.yaml");
+
+  const auto eggsCollection = eggsSection["collection"];
+  if (not eggsCollection)
+    throw std::runtime_error("Missing eggs collection in pets.yaml");
+
+  const auto petsCollection = petsSection["collection"];
+  if (not petsCollection)
+    throw std::runtime_error("Missing pets collection in pets.yaml");
+
+  Clear();
+
+  for (const auto& eggSection : eggsCollection)
   {
     EggInfo info;
     const auto eggItemTid = ReadEggInfo(eggSection, info);

--- a/src/libserver/registry/QuestRegistry.cpp
+++ b/src/libserver/registry/QuestRegistry.cpp
@@ -111,6 +111,13 @@ void ReadQuestRewardPoint(QuestRewardPoint& entry, const YAML::Node& yaml)
 
 } // anonymous namespace
 
+void QuestRegistry::Clear()
+{
+  _quests.clear();
+  _rewards.clear();
+  _rewardPoints.clear();
+}
+
 void QuestRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
   const auto root = YAML::LoadFile(configPath.string());
@@ -127,9 +134,7 @@ void QuestRegistry::ReadConfig(const std::filesystem::path& configPath)
   if (not collectionSection)
     throw std::runtime_error("Missing quests.collection section");
 
-  _rewards.clear();
-  _quests.clear();
-  _rewardPoints.clear();
+  Clear();
 
   for (const auto& rewardNode : rewardsSection)
   {

--- a/src/libserver/registry/SpeedRegistry.cpp
+++ b/src/libserver/registry/SpeedRegistry.cpp
@@ -28,6 +28,11 @@
 namespace server::registry
 {
 
+void SpeedRegistry::Clear()
+{
+  _teamSpurGaugeInfoMap.clear();
+}
+
 void SpeedRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
   const auto root = YAML::LoadFile(configPath.string());
@@ -40,7 +45,7 @@ void SpeedRegistry::ReadConfig(const std::filesystem::path& configPath)
   if (not teamSpurGaugeInfoSection)
     throw std::runtime_error("Missing teamSpurGaugeInfo section in speed.yaml");
 
-  _teamSpurGaugeInfoMap.clear();
+  Clear();
 
   for (const auto& entry : teamSpurGaugeInfoSection)
   {

--- a/src/libserver/registry/SystemContentRegistry.cpp
+++ b/src/libserver/registry/SystemContentRegistry.cpp
@@ -26,23 +26,28 @@
 namespace server::registry
 {
 
+void SystemContentRegistry::Clear()
+{
+  std::scoped_lock lock(_mutex);
+  _configPath.clear();
+  _entries.clear();
+}
+
 void SystemContentRegistry::ReadConfig(const std::filesystem::path& configPath)
 {
+  if (not std::filesystem::exists(configPath))
+    return;
+
+  const auto root = YAML::LoadFile(configPath.string());
+  if (not root.IsSequence())
+    return;
+
+  Clear();
+
+  std::scoped_lock lock(_mutex);
   _configPath = configPath;
 
-  if (not std::filesystem::exists(_configPath))
-  {
-    return;
-  }
-
-  const auto root = YAML::LoadFile(_configPath.string());
-  
-  std::scoped_lock lock(_mutex);
-  _entries.clear();
-
-  if (root.IsSequence())
-  {
-    for (const auto& node : root)
+  for (const auto& node : root)
     {
       SystemEntry entry;
       entry.type = node["type"].as<uint32_t>();
@@ -60,7 +65,6 @@ void SystemContentRegistry::ReadConfig(const std::filesystem::path& configPath)
       
       _entries.push_back(entry);
     }
-  }
 
   spdlog::info("System content registry loaded {} parameters", _entries.size());
 }

--- a/src/libserver/registry/SystemContentRegistry.cpp
+++ b/src/libserver/registry/SystemContentRegistry.cpp
@@ -28,7 +28,6 @@ namespace server::registry
 
 void SystemContentRegistry::Clear()
 {
-  std::scoped_lock lock(_mutex);
   _configPath.clear();
   _entries.clear();
 }
@@ -42,9 +41,8 @@ void SystemContentRegistry::ReadConfig(const std::filesystem::path& configPath)
   if (not root.IsSequence())
     return;
 
-  Clear();
-
   std::scoped_lock lock(_mutex);
+  Clear();
   _configPath = configPath;
 
   for (const auto& node : root)

--- a/src/server/system/ModerationSystem.cpp
+++ b/src/server/system/ModerationSystem.cpp
@@ -24,6 +24,11 @@
 namespace server
 {
 
+void ModerationSystem::Clear()
+{
+  _words.clear();
+}
+
 void ModerationSystem::ReadConfig(
   const std::filesystem::path& configPath)
 {
@@ -36,6 +41,8 @@ void ModerationSystem::ReadConfig(
   const auto wordsCollectionSection = wordsSection["collection"];
   if (not wordsCollectionSection)
     throw std::runtime_error("Missing words collection section");
+
+  Clear();
 
   for (const auto& wordSection : wordsCollectionSection)
   {


### PR DESCRIPTION
Fixes an issue were some registries were not properly clearing member states.

PR implements abstract Registry for registries to inherit which includes the new Clear() function, this clears and resets private member states back to default for loading, just before reading the configs.