### PR TITLE
feature(data): evict (character) record from data director

### DIFF
--- a/include/libserver/data/DataDirector.hpp
+++ b/include/libserver/data/DataDirector.hpp
@@ -72,6 +72,9 @@ public:
   //! @param userName Name of the user.
   //! @param characterUid UID of the character.
   void RequestLoadCharacterData(const std::string& userName, data::Uid characterUid);
+  //! Expires character data and associated sub records from cache and requests a reload.
+  //! @param userName Name of the user.
+  void ExpireCharacterData(const std::string& userName);
 
   //! Returns whether the data of a user (either user data or character data) are being loaded.
   //! @param userName name of the user.

--- a/include/libserver/data/DataStorage.hpp
+++ b/include/libserver/data/DataStorage.hpp
@@ -317,9 +317,14 @@ private:
     for (const auto& key : _retrieveQueue.data)
     {
       std::unique_lock lock(_entriesMutex);
-      auto& entry = _entries[key];
+      const auto entryIter = _entries.find(key);
+      const bool hasEntry = entryIter != _entries.cend();
       lock.unlock();
 
+      if (not hasEntry)
+        continue;
+
+      auto& entry = entryIter->second;
       if (_dataSourceRetrieveListener(key, entry.value))
       {
         entry.available.store(true, std::memory_order::relaxed);
@@ -347,7 +352,7 @@ private:
     {
       std::unique_lock lock(_entriesMutex);
       const auto entryIter = _entries.find(key);
-      const bool hasEntry = entryIter != _entries.end();
+      const bool hasEntry = entryIter != _entries.cend();
       lock.unlock();
 
       if (not hasEntry)
@@ -370,7 +375,7 @@ private:
     {
       std::unique_lock lock(_entriesMutex);
       const auto entryIter = _entries.find(key);
-      const bool hasEntry = entryIter != _entries.end();
+      const bool hasEntry = entryIter != _entries.cend();
       lock.unlock();
 
       if (not hasEntry)

--- a/include/libserver/data/DataStorage.hpp
+++ b/include/libserver/data/DataStorage.hpp
@@ -249,18 +249,31 @@ public:
   //! @param key Key of the datum.
   void Evict(const Key& key)
   {
-    std::scoped_lock lock(_entriesMutex);
-    _entries.erase(key);
+    {
+      std::scoped_lock lock(_storeQueue.mutex);
+      _storeQueue.data.erase(key);
+    }
+    {
+      std::scoped_lock lock(_retrieveQueue.mutex);
+      _retrieveQueue.data.erase(key);
+    }
+    {
+      std::scoped_lock lock(_deleteQueue.mutex);
+      _deleteQueue.data.erase(key);
+    }
+    {
+      std::scoped_lock lock(_entriesMutex);
+      _entries.erase(key);
+    }
   }
 
   //! Evicts multiple entries from memory cache without deleting from data source.
   //! @param keys Keys of the data.
   void Evict(KeySpan keys)
   {
-    std::scoped_lock lock(_entriesMutex);
     for (const auto& key : keys)
     {
-      _entries.erase(key);
+      Evict(key);
     }
   }
 

--- a/include/libserver/data/DataStorage.hpp
+++ b/include/libserver/data/DataStorage.hpp
@@ -245,6 +245,25 @@ public:
     RequestDelete(key);
   }
 
+  //! Evicts an entry from memory cache without deleting from data source.
+  //! @param key Key of the datum.
+  void Evict(const Key& key)
+  {
+    std::scoped_lock lock(_entriesMutex);
+    _entries.erase(key);
+  }
+
+  //! Evicts multiple entries from memory cache without deleting from data source.
+  //! @param keys Keys of the data.
+  void Evict(KeySpan keys)
+  {
+    std::scoped_lock lock(_entriesMutex);
+    for (const auto& key : keys)
+    {
+      _entries.erase(key);
+    }
+  }
+
   std::vector<Key> GetKeys()
   {
     std::vector<Key> keys;

--- a/src/libserver/data/DataDirector.cpp
+++ b/src/libserver/data/DataDirector.cpp
@@ -864,6 +864,71 @@ void DataDirector::RequestLoadCharacterData(
   ScheduleCharacterLoad(userDataContext, characterUid);
 }
 
+void DataDirector::ExpireCharacterData(
+  const std::string& userName)
+{
+  const auto userRecord = GetUser(userName);
+  if (not userRecord)
+    return;
+
+  data::Uid characterUid = data::InvalidUid;
+  userRecord.Immutable([&characterUid](const data::User& user)
+  {
+    characterUid = user.characterUid();
+  });
+
+  if (characterUid == data::InvalidUid)
+    return;
+
+  // Individually evict every cached sub-record from the character record
+  if (const auto characterRecord = _characterStorage.Get(characterUid, false))
+  {
+    characterRecord->Immutable([this](const data::Character& character)
+    {
+      if (character.settingsUid() != data::InvalidUid)
+        _settingsStorage.Evict(character.settingsUid());
+
+      if (character.dailyQuestGroupUid() != data::InvalidUid)
+        _dailyQuestGroupStorage.Evict(character.dailyQuestGroupUid());
+
+      _horseStorage.Evict(character.horses());
+      if (character.mountUid() != data::InvalidUid)
+        _horseStorage.Evict(character.mountUid());
+      for (const auto horseUid : character.breedingWishlist())
+        _horseStorage.Evict(horseUid);
+
+      _itemStorage.Evict(character.inventory());
+      _itemStorage.Evict(character.characterEquipment());
+
+      _storageItemStorage.Evict(character.gifts());
+      _storageItemStorage.Evict(character.purchases());
+
+      _eggStorage.Evict(character.eggs());
+      _petStorage.Evict(character.pets());
+      if (character.petUid() != data::InvalidUid)
+        _petStorage.Evict(character.petUid());
+
+      _housingStorage.Evict(character.housing());
+
+      _mailStorage.Evict(character.mailbox.inbox());
+      _mailStorage.Evict(character.mailbox.sent());
+
+      _questStorage.Evict(character.quests());
+    });
+  }
+
+  // Evict the character itself
+  _characterStorage.Evict(characterUid);
+
+  // Reset loaded status for the user context and trigger a fresh load
+  auto& userDataContext = _userDataContext[userName];
+  userDataContext.isCharacterDataLoaded.store(false, std::memory_order::relaxed);
+  userDataContext.isBeingLoaded.store(false, std::memory_order::relaxed);
+
+  // Immediately request a load of the character data
+  RequestLoadCharacterData(userName, characterUid);
+}
+
 bool DataDirector::AreDataBeingLoaded(const std::string& userName)
 {
   const auto& userDataContext = _userDataContext[userName];

--- a/src/server/system/ChatSystem.cpp
+++ b/src/server/system/ChatSystem.cpp
@@ -2325,29 +2325,67 @@ void ChatSystem::RegisterAdminCommands()
   _commandManager.RegisterCommand(
     "reload",
     [this](
-      [[maybe_unused]] const std::span<const std::string>& arguments,
-      [[maybe_unused]] data::Uid characterUid) -> std::vector<std::string>
+      const std::span<const std::string>& arguments,
+      data::Uid characterUid) -> std::vector<std::string>
     {
       const auto invokerRank = GetRoleRank(characterUid);
       if (not invokerRank || *invokerRank != data::Character::RoleRank::Admin)
         return {};
 
-      try
+      if (arguments.empty())
       {
-        _serverInstance.LoadConfigurations();
-      }
-      catch (const std::exception& x)
-      {
-        spdlog::error("Failed to load configurations: {}", x.what());
         return {
-          "Error trying to load game"
-          "and server configs."
-          "See the server console."};
+          "reload",
+          "  config",
+          "  character [username]"};
+      }
+
+      if (arguments[0] == "config")
+      {
+        try
+        {
+          _serverInstance.LoadConfigurations();
+        }
+        catch (const std::exception& x)
+        {
+          spdlog::error("Failed to load configurations: {}", x.what());
+          return {
+            "Error trying to load game"
+            "and server configs."
+            "See the server console."};
+        }
+
+        return {
+          "Game and server configs",
+          "were reloaded"};
+      }
+
+      if (arguments[0] == "character")
+      {
+        if (arguments.size() < 2)
+          return {"reload character [username]"};
+
+        const std::string& targetUserName = arguments[1];
+        try
+        {
+          _serverInstance.GetDataDirector().ExpireCharacterData(targetUserName);
+        }
+        catch (const std::exception& x)
+        {
+          spdlog::error(
+            "Failed to reload character for user '{}' from data source: {}",
+            targetUserName,
+            x.what());
+          return {std::format("Failed to reload character: {}", x.what())};
+        }
+
+        return {std::format("Character for user '{}' reloaded", targetUserName)};
       }
 
       return {
-        "Game and server configs",
-        "were reloaded"};
+        "reload",
+        "  config",
+        "  character [username]"};
     });
 }
 


### PR DESCRIPTION
Introduces the evict feature for data storage that evicts keys.

This is used by the data director `ExpireCharacterData` to evict the character and its sub-records and force reload the character data into memory.