### PR TITLE
feature(magic): libconfig magic distribution

### DIFF
--- a/include/libserver/registry/MagicRegistry.hpp
+++ b/include/libserver/registry/MagicRegistry.hpp
@@ -117,6 +117,21 @@ struct Magic
     //! Effect 3: fraction of the passive regen granted while holding a spell, in bp. e.g. 2000 → 20%.
     uint32_t holdingGaugeScaleBp{2000};
   };
+
+  //! Team modifier offset entry.
+  struct TeamModifier
+  {
+    uint32_t targetId{}; // group ID or basicType
+    uint32_t lead{};     // 1 if team leads, 0 if team trails
+    std::array<int32_t, 4> aheadOffsets{}; // offsets for ahead_1..ahead_4
+  };
+
+  //! Client-matching general magic config parameters.
+  struct Config
+  {
+    uint32_t lastSpurtCritBonusBp{1000};
+    float lastSpurtProgressThreshold{0.85f};
+  };
 };
 
 class MagicRegistry : public Registry
@@ -144,9 +159,20 @@ public:
   //! Returns the stat scaling for a basicType, or nullptr if none applies.
   [[nodiscard]] const Magic::StatScaling* GetStatScaling(uint32_t basicType) const;
 
-  //! Returns the position weights for use in random magic selection.
+  //! Returns the position weights for use in random magic selection (legacy fallback).
   [[nodiscard]] const std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>& GetSoloPositionWeights(uint32_t position) const;
   [[nodiscard]] const std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>& GetTeamPositionWeights(uint32_t position) const;
+
+  //! Game client distribution tables:
+  [[nodiscard]] uint32_t GetCanonicalRank(size_t totalRacers, size_t racerRank) const;
+  [[nodiscard]] const std::vector<std::pair<uint32_t, uint32_t>>& GetSoloGroupWeights(uint32_t canonicalRank) const;
+  [[nodiscard]] const std::vector<std::pair<uint32_t, uint32_t>>& GetTeamGroupWeights(uint32_t canonicalRank) const;
+  [[nodiscard]] const std::vector<std::pair<uint32_t, uint32_t>>& GetAttackGroupWeights(uint32_t canonicalRank) const;
+  [[nodiscard]] const std::vector<std::pair<uint32_t, uint32_t>>& GetTeamAssistanceWeights(uint32_t canonicalRank) const;
+
+  [[nodiscard]] int32_t GetGroupTeamModifier(uint32_t groupId, bool isLead, uint32_t aheadCount) const;
+  [[nodiscard]] int32_t GetSlotTeamModifier(uint32_t basicType, bool isLead, uint32_t aheadCount) const;
+  [[nodiscard]] const Magic::Config& GetConfig() const;
 
 private:
   std::unordered_map<uint32_t, Magic::SlotInfo> _slotInfo{};
@@ -154,12 +180,26 @@ private:
   std::vector<uint32_t> _teamPool{};
   Magic::RegenInfo _regenInfo{};
   Magic::SetBonusInfo _setBonusInfo{};
+  Magic::Config _config{};
   uint32_t _baseCritChanceBp{500};
   //! Keyed by basicType.
   std::unordered_map<uint32_t, Magic::StatScaling> _statScalings{};
-  //! Position weights for use in random magic selection.
-  std::array<std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>, 8> _soloPositionWeights;
-  std::array<std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>, 8> _teamPositionWeights;
+  //! Position weights for legacy fallback.
+  std::array<std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>, 8> _soloPositionWeights{};
+  std::array<std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>, 8> _teamPositionWeights{};
+
+  //! Client distribution tables (indexed by canonicalRank - 1, 0..7)
+  std::array<std::vector<std::pair<uint32_t, uint32_t>>, 8> _soloGroupWeights{};
+  std::array<std::vector<std::pair<uint32_t, uint32_t>>, 8> _teamGroupWeights{};
+  std::array<std::vector<std::pair<uint32_t, uint32_t>>, 8> _attackGroupWeights{};
+  std::array<std::vector<std::pair<uint32_t, uint32_t>>, 8> _teamAssistanceWeights{};
+
+  //! Team modifiers
+  std::vector<Magic::TeamModifier> _groupTeamModifiers{};
+  std::vector<Magic::TeamModifier> _slotTeamModifiers{};
+
+  //! Ranking conversion table [playerCount - 1][racerRank - 1] -> canonicalRank (1..8)
+  std::array<std::vector<uint32_t>, 8> _rankingConversion{};
 };
 
 } // namespace server::registry

--- a/resources/config/game/magic.yaml
+++ b/resources/config/game/magic.yaml
@@ -807,3 +807,112 @@ magic:
       stat: ambition
       critStepBp: 250
       targetDurationReductionBp: 5
+
+  # Group Distribution Ratios (MagicGroupRatio) for Solo mode by rank (1..8)
+  # Groups: 1=Attack, 2=WaterShield, 3=Booster, 4=IceWall, 5=TeamAssist, 6=HotRodding, 7=BufSpeed
+  groupRatio:
+    - group: 1
+      ranks: [0, 45, 60, 65, 65, 60, 44, 11]
+    - group: 2
+      ranks: [60, 15, 0, 0, 0, 0, 0, 0]
+    - group: 3
+      ranks: [5, 40, 30, 25, 40, 35, 44, 82]
+    - group: 4
+      ranks: [35, 0, 0, 0, 0, 0, 0, 0]
+    - group: 5
+      ranks: [0, 0, 5, 3, 3, 3, 0, 0]
+    - group: 6
+      ranks: [0, 0, 0, 0, 0, 0, 4, 11]
+    - group: 7
+      ranks: [0, 0, 0, 0, 0, 0, 22, 22]
+
+  # Group Distribution Ratios (MagicGroupTeamRatio) for Team mode by rank (1..8)
+  groupTeamRatio:
+    - group: 1
+      ranks: [0, 45, 50, 65, 65, 60, 44, 11]
+    - group: 2
+      ranks: [60, 15, 0, 0, 0, 0, 0, 0]
+    - group: 3
+      ranks: [5, 40, 30, 25, 40, 35, 44, 82]
+    - group: 4
+      ranks: [35, 0, 0, 0, 0, 0, 0, 0]
+    - group: 5
+      ranks: [0, 0, 5, 3, 3, 3, 0, 0]
+    - group: 6
+      ranks: [0, 0, 0, 0, 0, 0, 4, 11]
+    - group: 7
+      ranks: [0, 0, 0, 0, 0, 0, 22, 22]
+
+  # Sub-distribution within Group 1 (Attacks) by rank (1..8) (MagicGroupAttackRatio)
+  groupAttackRatio:
+    - basicType: 2   # FireBall
+      ranks: [0, 15, 15, 10, 10, 25, 5, 10]
+    - basicType: 14  # DarkFire
+      ranks: [0, 20, 17, 10, 10, 15, 10, 10]
+    - basicType: 16  # Summon
+      ranks: [0, 5, 15, 15, 15, 10, 10, 5]
+    - basicType: 12  # JumpStun
+      ranks: [0, 0, 0, 0, 5, 5, 0, 0]
+
+  # Sub-distribution within Group 5 (Team Assistance) by rank (1..8) (MagicGroupTeamAssistanceRatio)
+  groupTeamAssistanceRatio:
+    - basicType: 20  # BufPower
+      ranks: [0, 0, 0, 0, 0, 0, 20, 20]
+    - basicType: 22  # BufGauge
+      ranks: [0, 0, 0, 0, 0, 0, 0, 0]
+    - basicType: 24  # BufSpeed
+      ranks: [0, 0, 0, 0, 0, 0, 80, 80]
+
+  # Team Mode Group Modifiers (MagicGroupTeamModifier)
+  # Ahead count represents how many opponents are ahead (1..4)
+  groupTeamModifier:
+    - group: 1
+      lead: 0
+      aheadOffsets: [10, 10, 10, 10]
+    - group: 1
+      lead: 1
+      aheadOffsets: [-10, -10, -10, -10]
+    - group: 2
+      lead: 1
+      aheadOffsets: [10, 5, 0, 0]
+    - group: 5
+      lead: 1
+      aheadOffsets: [-100, -100, -100, -100]
+    - group: 7
+      lead: 1
+      aheadOffsets: [-10, -10, -20, -20]
+
+  # Team Mode Slot Modifiers (MagicSlotTeamModifier)
+  slotTeamModifier:
+    - basicType: 24  # BufSpeed
+      lead: 0
+      aheadOffsets: [10, 20, 30, 40]
+    - basicType: 20  # BufPower
+      lead: 0
+      aheadOffsets: [10, 20, 30, 40]
+
+  # Ranking Conversion Table (RankingConversionInfo)
+  # Maps actual placement in a race of N players to canonical rank (1..8)
+  rankingConversion:
+    - playerCount: 1
+      canonicalRanks: [1]
+    - playerCount: 2
+      canonicalRanks: [1, 2]
+    - playerCount: 3
+      canonicalRanks: [1, 2, 8]
+    - playerCount: 4
+      canonicalRanks: [1, 2, 4, 8]
+    - playerCount: 5
+      canonicalRanks: [1, 2, 4, 5, 8]
+    - playerCount: 6
+      canonicalRanks: [1, 2, 4, 5, 7, 8]
+    - playerCount: 7
+      canonicalRanks: [1, 2, 3, 4, 5, 7, 8]
+    - playerCount: 8
+      canonicalRanks: [1, 2, 3, 4, 5, 6, 7, 8]
+
+  # Client-matching MagicConfig settings
+  config:
+    lastSpurtCritBonusBp: 1000   # +10% crit bonus during LastSpurt
+    lastSpurtProgressThreshold: 0.85 # Race progress >= 85% triggers LastSpurt bonus
+

--- a/src/libserver/registry/MagicRegistry.cpp
+++ b/src/libserver/registry/MagicRegistry.cpp
@@ -87,8 +87,21 @@ void MagicRegistry::Clear()
     weights.clear();
   for (auto& weights : _teamPositionWeights)
     weights.clear();
+  for (auto& weights : _soloGroupWeights)
+    weights.clear();
+  for (auto& weights : _teamGroupWeights)
+    weights.clear();
+  for (auto& weights : _attackGroupWeights)
+    weights.clear();
+  for (auto& weights : _teamAssistanceWeights)
+    weights.clear();
+  _groupTeamModifiers.clear();
+  _slotTeamModifiers.clear();
+  for (auto& conv : _rankingConversion)
+    conv.clear();
   _regenInfo = {};
   _setBonusInfo = {};
+  _config = {};
   _baseCritChanceBp = 500;
 }
 
@@ -196,6 +209,100 @@ void MagicRegistry::ReadConfig(const std::filesystem::path& configPath)
     }
   }
 
+  // Parse groupRatio (Solo)
+  if (const auto groupRatioSection = magicSection["groupRatio"])
+  {
+    for (const auto& entry : groupRatioSection)
+    {
+      const auto groupId = entry["group"].as<uint32_t>();
+      const auto ranks = entry["ranks"].as<std::array<uint32_t, 8>>();
+      for (size_t r = 0; r < 8; ++r)
+        _soloGroupWeights[r].emplace_back(groupId, ranks[r]);
+    }
+  }
+
+  // Parse groupTeamRatio (Team)
+  if (const auto groupTeamRatioSection = magicSection["groupTeamRatio"])
+  {
+    for (const auto& entry : groupTeamRatioSection)
+    {
+      const auto groupId = entry["group"].as<uint32_t>();
+      const auto ranks = entry["ranks"].as<std::array<uint32_t, 8>>();
+      for (size_t r = 0; r < 8; ++r)
+        _teamGroupWeights[r].emplace_back(groupId, ranks[r]);
+    }
+  }
+
+  // Parse groupAttackRatio (Attacks)
+  if (const auto groupAttackRatioSection = magicSection["groupAttackRatio"])
+  {
+    for (const auto& entry : groupAttackRatioSection)
+    {
+      const auto basicType = entry["basicType"].as<uint32_t>();
+      const auto ranks = entry["ranks"].as<std::array<uint32_t, 8>>();
+      for (size_t r = 0; r < 8; ++r)
+        _attackGroupWeights[r].emplace_back(basicType, ranks[r]);
+    }
+  }
+
+  // Parse groupTeamAssistanceRatio (Team Assistance)
+  if (const auto groupTeamAssistanceRatioSection = magicSection["groupTeamAssistanceRatio"])
+  {
+    for (const auto& entry : groupTeamAssistanceRatioSection)
+    {
+      const auto basicType = entry["basicType"].as<uint32_t>();
+      const auto ranks = entry["ranks"].as<std::array<uint32_t, 8>>();
+      for (size_t r = 0; r < 8; ++r)
+        _teamAssistanceWeights[r].emplace_back(basicType, ranks[r]);
+    }
+  }
+
+  // Parse groupTeamModifier
+  if (const auto groupTeamModifierSection = magicSection["groupTeamModifier"])
+  {
+    for (const auto& entry : groupTeamModifierSection)
+    {
+      Magic::TeamModifier mod{};
+      mod.targetId = entry["group"].as<uint32_t>();
+      mod.lead = entry["lead"].as<uint32_t>();
+      mod.aheadOffsets = entry["aheadOffsets"].as<std::array<int32_t, 4>>();
+      _groupTeamModifiers.push_back(mod);
+    }
+  }
+
+  // Parse slotTeamModifier
+  if (const auto slotTeamModifierSection = magicSection["slotTeamModifier"])
+  {
+    for (const auto& entry : slotTeamModifierSection)
+    {
+      Magic::TeamModifier mod{};
+      mod.targetId = entry["basicType"].as<uint32_t>();
+      mod.lead = entry["lead"].as<uint32_t>();
+      mod.aheadOffsets = entry["aheadOffsets"].as<std::array<int32_t, 4>>();
+      _slotTeamModifiers.push_back(mod);
+    }
+  }
+
+  // Parse rankingConversion
+  if (const auto rankingConversionSection = magicSection["rankingConversion"])
+  {
+    for (const auto& entry : rankingConversionSection)
+    {
+      const auto playerCount = entry["playerCount"].as<size_t>();
+      if (playerCount >= 1 && playerCount <= 8)
+      {
+        _rankingConversion[playerCount - 1] = entry["canonicalRanks"].as<std::vector<uint32_t>>();
+      }
+    }
+  }
+
+  // Parse general config
+  if (const auto configSection = magicSection["config"])
+  {
+    _config.lastSpurtCritBonusBp = configSection["lastSpurtCritBonusBp"].as<uint32_t>(_config.lastSpurtCritBonusBp);
+    _config.lastSpurtProgressThreshold = configSection["lastSpurtProgressThreshold"].as<float>(_config.lastSpurtProgressThreshold);
+  }
+
   spdlog::info(
     "Magic registry loaded {} slot(s) ({} solo, {} team)",
     _slotInfo.size(),
@@ -265,6 +372,77 @@ const std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>& MagicRegistry:
 const std::vector<std::pair<Magic::SlotWeight, Magic::SlotInfo>>& MagicRegistry::GetTeamPositionWeights(uint32_t position) const
 {
   return _teamPositionWeights.at(position);
+}
+
+uint32_t MagicRegistry::GetCanonicalRank(size_t totalRacers, size_t racerRank) const
+{
+  if (totalRacers == 0 || racerRank == 0)
+    return 1;
+
+  const size_t pIdx = std::clamp(totalRacers, size_t{1}, size_t{8}) - 1;
+  const auto& table = _rankingConversion[pIdx];
+  if (table.empty())
+    return std::clamp<uint32_t>(static_cast<uint32_t>(racerRank), 1, 8);
+
+  const size_t rIdx = std::clamp(racerRank, size_t{1}, table.size()) - 1;
+  return table[rIdx];
+}
+
+const std::vector<std::pair<uint32_t, uint32_t>>& MagicRegistry::GetSoloGroupWeights(uint32_t canonicalRank) const
+{
+  const size_t idx = std::clamp<uint32_t>(canonicalRank, 1, 8) - 1;
+  return _soloGroupWeights[idx];
+}
+
+const std::vector<std::pair<uint32_t, uint32_t>>& MagicRegistry::GetTeamGroupWeights(uint32_t canonicalRank) const
+{
+  const size_t idx = std::clamp<uint32_t>(canonicalRank, 1, 8) - 1;
+  return _teamGroupWeights[idx];
+}
+
+const std::vector<std::pair<uint32_t, uint32_t>>& MagicRegistry::GetAttackGroupWeights(uint32_t canonicalRank) const
+{
+  const size_t idx = std::clamp<uint32_t>(canonicalRank, 1, 8) - 1;
+  return _attackGroupWeights[idx];
+}
+
+const std::vector<std::pair<uint32_t, uint32_t>>& MagicRegistry::GetTeamAssistanceWeights(uint32_t canonicalRank) const
+{
+  const size_t idx = std::clamp<uint32_t>(canonicalRank, 1, 8) - 1;
+  return _teamAssistanceWeights[idx];
+}
+
+int32_t MagicRegistry::GetGroupTeamModifier(uint32_t groupId, bool isLead, uint32_t aheadCount) const
+{
+  const uint32_t leadVal = isLead ? 1 : 0;
+  for (const auto& mod : _groupTeamModifiers)
+  {
+    if (mod.targetId == groupId && mod.lead == leadVal)
+    {
+      const size_t aheadIdx = std::clamp<uint32_t>(aheadCount, 1, 4) - 1;
+      return mod.aheadOffsets[aheadIdx];
+    }
+  }
+  return 0;
+}
+
+int32_t MagicRegistry::GetSlotTeamModifier(uint32_t basicType, bool isLead, uint32_t aheadCount) const
+{
+  const uint32_t leadVal = isLead ? 1 : 0;
+  for (const auto& mod : _slotTeamModifiers)
+  {
+    if (mod.targetId == basicType && mod.lead == leadVal)
+    {
+      const size_t aheadIdx = std::clamp<uint32_t>(aheadCount, 1, 4) - 1;
+      return mod.aheadOffsets[aheadIdx];
+    }
+  }
+  return 0;
+}
+
+const Magic::Config& MagicRegistry::GetConfig() const
+{
+  return _config;
 }
 
 } // namespace server::registry

--- a/src/server/race/MagicSystem.cpp
+++ b/src/server/race/MagicSystem.cpp
@@ -24,6 +24,7 @@
 #include <libserver/util/Util.hpp>
 
 #include <algorithm>
+#include <numeric>
 #include <random>
 #include <ranges>
 
@@ -263,25 +264,114 @@ const registry::Magic::SlotInfo& MagicSystem::SelectMagicTypeByPosition(
   uint32_t position,
   bool isTeam)
 {
-  // Validate position
+  // Validate position (0..7)
   if (position > 7)
     throw std::out_of_range("Position must be between 0 and 7");
 
-  // Get the weights for the specified position
-  const auto& positionSlotInfoWeights = isTeam ? magicRegistry.GetTeamPositionWeights(position) : magicRegistry.GetSoloPositionWeights(position);
+  const uint32_t canonicalRank = position + 1;
+  const auto& groupWeights = isTeam
+    ? magicRegistry.GetTeamGroupWeights(canonicalRank)
+    : magicRegistry.GetSoloGroupWeights(canonicalRank);
 
-  // Keep reference to weights only for the discrete distribution
-  const auto& positionWeights = positionSlotInfoWeights | std::views::keys;
+  if (groupWeights.empty())
+  {
+    // Fallback to legacy position weights if group weights not configured
+    const auto& legacyWeights = isTeam
+      ? magicRegistry.GetTeamPositionWeights(position)
+      : magicRegistry.GetSoloPositionWeights(position);
 
-  // Create a discrete distribution based on the weights
-  std::discrete_distribution<uint32_t> dist(
-    positionWeights.cbegin(),
-    positionWeights.cend());
+    const auto& weights = legacyWeights | std::views::keys;
+    std::discrete_distribution<uint32_t> dist(weights.cbegin(), weights.cend());
+    return legacyWeights[dist(server::util::GetRandomEngine())].second;
+  }
 
-  // Select a random index based on the distribution
-  // and map the discrete index to the corresponding magic item
-  const uint32_t selectedIndex = dist(server::util::GetRandomEngine());
-  return positionSlotInfoWeights[selectedIndex].second;
+  std::vector<uint32_t> groupIds;
+  std::vector<uint32_t> weights;
+  groupIds.reserve(groupWeights.size());
+  weights.reserve(groupWeights.size());
+
+  for (const auto& [groupId, weight] : groupWeights)
+  {
+    groupIds.push_back(groupId);
+    weights.push_back(weight);
+  }
+
+  std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
+  const uint32_t selectedGroup = groupIds[dist(server::util::GetRandomEngine())];
+
+  uint32_t basicType = MagicType::WaterShield;
+  switch (selectedGroup)
+  {
+    case 1: // Attack Group
+    {
+      const auto& attackWeights = magicRegistry.GetAttackGroupWeights(canonicalRank);
+      if (not attackWeights.empty())
+      {
+        std::vector<uint32_t> attackTypes;
+        std::vector<uint32_t> subWeights;
+        for (const auto& [type, w] : attackWeights)
+        {
+          attackTypes.push_back(type);
+          subWeights.push_back(w);
+        }
+        std::discrete_distribution<size_t> attackDist(subWeights.begin(), subWeights.end());
+        basicType = attackTypes[attackDist(server::util::GetRandomEngine())];
+      }
+      else
+      {
+        basicType = MagicType::FireBall;
+      }
+      break;
+    }
+    case 2: // Defense
+      basicType = MagicType::WaterShield;
+      break;
+    case 3: // Booster
+      basicType = MagicType::Booster;
+      break;
+    case 4: // Rear hazard
+      basicType = MagicType::IceWall;
+      break;
+    case 5: // Team Assistance
+    {
+      if (isTeam)
+      {
+        const auto& assistWeights = magicRegistry.GetTeamAssistanceWeights(canonicalRank);
+        if (not assistWeights.empty())
+        {
+          std::vector<uint32_t> assistTypes;
+          std::vector<uint32_t> subWeights;
+          for (const auto& [type, w] : assistWeights)
+          {
+            assistTypes.push_back(type);
+            subWeights.push_back(w);
+          }
+          std::discrete_distribution<size_t> assistDist(subWeights.begin(), subWeights.end());
+          basicType = assistTypes[assistDist(server::util::GetRandomEngine())];
+        }
+        else
+        {
+          basicType = MagicType::BufSpeed;
+        }
+      }
+      else
+      {
+        basicType = MagicType::WaterShield;
+      }
+      break;
+    }
+    case 6: // HotRodding
+      basicType = MagicType::HotRodding;
+      break;
+    case 7: // Team Acceleration
+      basicType = isTeam ? MagicType::BufSpeed : MagicType::Booster;
+      break;
+    default:
+      basicType = MagicType::WaterShield;
+      break;
+  }
+
+  return magicRegistry.GetSlotInfo(basicType);
 }
 
 const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
@@ -290,42 +380,185 @@ const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
   data::Uid racerUid)
 {
   const auto& racer = tracker.GetRacer(racerUid);
+  const bool isTeam =
+    racer.team == protocol::TeamColor::Red or
+    racer.team == protocol::TeamColor::Blue;
 
-  // Determine the racer's position (0 = 1st place)
-  uint32_t racerPosition = 0;
+  // Determine the racer's actual rank (1-indexed: 1 = 1st place)
+  // and count how many opponents are ahead for team modifiers.
+  uint32_t racerRank = 1;
+  uint32_t opponentsAhead = 0;
+  bool teamIsLeading = true;
+  float bestProgress = racer.raceProgress;
+  protocol::TeamColor leaderTeam = racer.team;
+
   const auto& allRacers = tracker.GetRacers();
-  size_t totalRacers = allRacers.size();
+  const size_t totalRacers = allRacers.size();
 
   for (const auto& [uid, instanceRacer] : allRacers)
   {
+    if (instanceRacer.raceProgress > bestProgress)
+    {
+      bestProgress = instanceRacer.raceProgress;
+      leaderTeam = instanceRacer.team;
+    }
+
     if (uid == racerUid)
       continue;
 
-    // TODO: do we ignore disconnected racers too?
-
-    // Check if instance racer is ahead of the racer requesting item
     if (instanceRacer.raceProgress > racer.raceProgress)
-      racerPosition++;
+    {
+      racerRank++;
+      if (isTeam && instanceRacer.team != racer.team)
+      {
+        opponentsAhead++;
+      }
+    }
   }
 
-  // Map the actual position to one of the 8 weight slots [0, 7] via linear interpolation.
-  // This ensures last place in a small race gets "last-place" item weights.
-  uint32_t effectivePosition = racerPosition;
-  if (totalRacers > 1)
+  if (isTeam)
   {
-    effectivePosition = static_cast<uint32_t>(
-      static_cast<float>(racerPosition) * 7.0f /
-      static_cast<float>(totalRacers - 1));
+    teamIsLeading = (leaderTeam == racer.team);
   }
 
-  // Clamp effective position to [0, 7] for safety
-  effectivePosition = std::clamp(effectivePosition, 0u, 7u);
+  // Canonical rank (1..8) from RankingConversionInfo
+  const uint32_t canonicalRank = magicRegistry.GetCanonicalRank(
+    totalRacers,
+    racerRank);
 
-  const registry::Magic::SlotInfo& magicSlotInfo = SelectMagicTypeByPosition(
-    magicRegistry,
-    effectivePosition,
-    racer.team == protocol::TeamColor::Red or racer.team == protocol::TeamColor::Blue);
+  // Fetch base group distribution
+  const auto& baseGroupWeights = isTeam
+    ? magicRegistry.GetTeamGroupWeights(canonicalRank)
+    : magicRegistry.GetSoloGroupWeights(canonicalRank);
 
+  uint32_t chosenBasicType = MagicType::WaterShield;
+
+  if (not baseGroupWeights.empty())
+  {
+    std::vector<uint32_t> groupIds;
+    std::vector<uint32_t> adjustedWeights;
+    groupIds.reserve(baseGroupWeights.size());
+    adjustedWeights.reserve(baseGroupWeights.size());
+
+    for (const auto& [groupId, baseWeight] : baseGroupWeights)
+    {
+      int32_t finalWeight = static_cast<int32_t>(baseWeight);
+      if (isTeam && opponentsAhead > 0)
+      {
+        finalWeight += magicRegistry.GetGroupTeamModifier(groupId, teamIsLeading, opponentsAhead);
+      }
+      groupIds.push_back(groupId);
+      adjustedWeights.push_back(std::max<uint32_t>(0, finalWeight));
+    }
+
+    // If all adjusted weights sum to 0, fallback to raw base weights
+    const uint32_t weightSum = std::accumulate(adjustedWeights.begin(), adjustedWeights.end(), 0u);
+    if (weightSum == 0)
+    {
+      adjustedWeights.clear();
+      for (const auto& [groupId, baseWeight] : baseGroupWeights)
+        adjustedWeights.push_back(baseWeight);
+    }
+
+    std::discrete_distribution<size_t> groupDist(adjustedWeights.begin(), adjustedWeights.end());
+    const uint32_t selectedGroup = groupIds[groupDist(server::util::GetRandomEngine())];
+
+    switch (selectedGroup)
+    {
+      case 1: // Attacks
+      {
+        const auto& attackWeights = magicRegistry.GetAttackGroupWeights(canonicalRank);
+        if (not attackWeights.empty())
+        {
+          std::vector<uint32_t> attackTypes;
+          std::vector<uint32_t> subWeights;
+          for (const auto& [type, w] : attackWeights)
+          {
+            attackTypes.push_back(type);
+            subWeights.push_back(w);
+          }
+          std::discrete_distribution<size_t> attackDist(subWeights.begin(), subWeights.end());
+          chosenBasicType = attackTypes[attackDist(server::util::GetRandomEngine())];
+        }
+        else
+        {
+          chosenBasicType = MagicType::FireBall;
+        }
+        break;
+      }
+      case 2: // Defense
+        chosenBasicType = MagicType::WaterShield;
+        break;
+      case 3: // Speed / Booster
+        chosenBasicType = MagicType::Booster;
+        break;
+      case 4: // Rear Hazard
+        chosenBasicType = MagicType::IceWall;
+        break;
+      case 5: // Team Assistance / Buffs
+      {
+        if (isTeam)
+        {
+          const auto& assistWeights = magicRegistry.GetTeamAssistanceWeights(canonicalRank);
+          if (not assistWeights.empty())
+          {
+            std::vector<uint32_t> assistTypes;
+            std::vector<uint32_t> subWeights;
+            for (const auto& [type, baseW] : assistWeights)
+            {
+              int32_t finalW = static_cast<int32_t>(baseW);
+              if (opponentsAhead > 0)
+                finalW += magicRegistry.GetSlotTeamModifier(type, teamIsLeading, opponentsAhead);
+              assistTypes.push_back(type);
+              subWeights.push_back(std::max<uint32_t>(0, finalW));
+            }
+
+            const uint32_t subSum = std::accumulate(subWeights.begin(), subWeights.end(), 0u);
+            if (subSum == 0)
+            {
+              subWeights.clear();
+              for (const auto& [type, baseW] : assistWeights)
+                subWeights.push_back(baseW);
+            }
+
+            std::discrete_distribution<size_t> assistDist(subWeights.begin(), subWeights.end());
+            chosenBasicType = assistTypes[assistDist(server::util::GetRandomEngine())];
+          }
+          else
+          {
+            chosenBasicType = MagicType::BufSpeed;
+          }
+        }
+        else
+        {
+          chosenBasicType = MagicType::WaterShield;
+        }
+        break;
+      }
+      case 6: // HotRodding
+        chosenBasicType = MagicType::HotRodding;
+        break;
+      case 7: // Team Acceleration / BufSpeed
+        chosenBasicType = isTeam ? MagicType::BufSpeed : MagicType::Booster;
+        break;
+      default:
+        chosenBasicType = MagicType::WaterShield;
+        break;
+    }
+  }
+  else
+  {
+    // Fallback if group tables were empty
+    const registry::Magic::SlotInfo& fallbackSlot = SelectMagicTypeByPosition(
+      magicRegistry,
+      std::clamp<uint32_t>(canonicalRank - 1, 0u, 7u),
+      isTeam);
+    chosenBasicType = fallbackSlot.basicType;
+  }
+
+  const registry::Magic::SlotInfo& magicSlotInfo = magicRegistry.GetSlotInfo(chosenBasicType);
+
+  // Roll critical upgrade
   uint32_t critChanceBp = magicRegistry.GetBaseCritChanceBp();
   if (magicSlotInfo.criticalType != 0)
   {
@@ -338,6 +571,10 @@ const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
     // Mount-equipment set bonus: increased critical spell chance.
     if (racer.activeSetEffect == registry::SetEquipEffect::CriticalSpellChance)
       critChanceBp += magicRegistry.GetSetBonusInfo().critChanceBonusBp;
+
+    // LastSpurt bonus (progress threshold from config)
+    if (racer.raceProgress >= magicRegistry.GetConfig().lastSpurtProgressThreshold)
+      critChanceBp += magicRegistry.GetConfig().lastSpurtCritBonusBp;
   }
 
   if (std::uniform_int_distribution<int>(0, 9999)(server::util::GetRandomEngine()) < static_cast<int>(critChanceBp))
@@ -347,3 +584,4 @@ const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
 }
 
 } // namespace server::race
+

--- a/src/server/race/MagicSystem.cpp
+++ b/src/server/race/MagicSystem.cpp
@@ -24,6 +24,7 @@
 #include <libserver/util/Util.hpp>
 
 #include <algorithm>
+#include <iostream>
 #include <numeric>
 #include <random>
 #include <ranges>
@@ -314,8 +315,16 @@ const registry::Magic::SlotInfo& MagicSystem::SelectMagicTypeByPosition(
           attackTypes.push_back(type);
           subWeights.push_back(w);
         }
-        std::discrete_distribution<size_t> attackDist(subWeights.begin(), subWeights.end());
-        basicType = attackTypes[attackDist(server::util::GetRandomEngine())];
+        const uint32_t attackSum = std::accumulate(subWeights.begin(), subWeights.end(), 0u);
+        if (attackSum > 0)
+        {
+          std::discrete_distribution<size_t> attackDist(subWeights.begin(), subWeights.end());
+          basicType = attackTypes[attackDist(server::util::GetRandomEngine())];
+        }
+        else
+        {
+          basicType = MagicType::FireBall;
+        }
       }
       else
       {
@@ -346,8 +355,16 @@ const registry::Magic::SlotInfo& MagicSystem::SelectMagicTypeByPosition(
             assistTypes.push_back(type);
             subWeights.push_back(w);
           }
-          std::discrete_distribution<size_t> assistDist(subWeights.begin(), subWeights.end());
-          basicType = assistTypes[assistDist(server::util::GetRandomEngine())];
+          const uint32_t assistSum = std::accumulate(subWeights.begin(), subWeights.end(), 0u);
+          if (assistSum > 0)
+          {
+            std::discrete_distribution<size_t> assistDist(subWeights.begin(), subWeights.end());
+            basicType = assistTypes[assistDist(server::util::GetRandomEngine())];
+          }
+          else
+          {
+            basicType = MagicType::BufSpeed;
+          }
         }
         else
         {
@@ -448,7 +465,7 @@ const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
         finalWeight += magicRegistry.GetGroupTeamModifier(groupId, teamIsLeading, opponentsAhead);
       }
       groupIds.push_back(groupId);
-      adjustedWeights.push_back(std::max<uint32_t>(0, finalWeight));
+      adjustedWeights.push_back(finalWeight > 0 ? static_cast<uint32_t>(finalWeight) : 0u);
     }
 
     // If all adjusted weights sum to 0, fallback to raw base weights
@@ -477,8 +494,16 @@ const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
             attackTypes.push_back(type);
             subWeights.push_back(w);
           }
-          std::discrete_distribution<size_t> attackDist(subWeights.begin(), subWeights.end());
-          chosenBasicType = attackTypes[attackDist(server::util::GetRandomEngine())];
+          const uint32_t attackSum = std::accumulate(subWeights.begin(), subWeights.end(), 0u);
+          if (attackSum > 0)
+          {
+            std::discrete_distribution<size_t> attackDist(subWeights.begin(), subWeights.end());
+            chosenBasicType = attackTypes[attackDist(server::util::GetRandomEngine())];
+          }
+          else
+          {
+            chosenBasicType = MagicType::FireBall;
+          }
         }
         else
         {
@@ -510,7 +535,7 @@ const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
               if (opponentsAhead > 0)
                 finalW += magicRegistry.GetSlotTeamModifier(type, teamIsLeading, opponentsAhead);
               assistTypes.push_back(type);
-              subWeights.push_back(std::max<uint32_t>(0, finalW));
+              subWeights.push_back(finalW > 0 ? static_cast<uint32_t>(finalW) : 0u);
             }
 
             const uint32_t subSum = std::accumulate(subWeights.begin(), subWeights.end(), 0u);
@@ -521,8 +546,16 @@ const registry::Magic::SlotInfo& MagicSystem::RandomMagicItem(
                 subWeights.push_back(baseW);
             }
 
-            std::discrete_distribution<size_t> assistDist(subWeights.begin(), subWeights.end());
-            chosenBasicType = assistTypes[assistDist(server::util::GetRandomEngine())];
+            const uint32_t finalSum = std::accumulate(subWeights.begin(), subWeights.end(), 0u);
+            if (finalSum > 0)
+            {
+              std::discrete_distribution<size_t> assistDist(subWeights.begin(), subWeights.end());
+              chosenBasicType = assistTypes[assistDist(server::util::GetRandomEngine())];
+            }
+            else
+            {
+              chosenBasicType = MagicType::BufSpeed;
+            }
           }
           else
           {


### PR DESCRIPTION
This PR implements libconfig-based positional and team-based magic item distribution tables and mechanics based on the game client's original configurations (`RankingConversionInfo`, `GroupPositionalItemProb`, `AttackGroupPositionalItemProb`, `TeamAssistancePositionalItemProb`, and team/slot modifiers), replacing the legacy linear interpolation fallback logic. It also introduces configurable Last Spurt critical spell roll bonuses.

This completely replaces the static positional magic item weights that was configured based on the initial survey results.

Values from libconfig:
- `RankingConversionInfo` - maps racers to position
- `MagicGroupRatio` - base distribution probabilities for magic items, by group
- `MagicGroupTeamRatio` - identical to `MagicGroupRatio` but for teams
- `MagicGroupAttackRatio`- offensive magic item sub-distribution probabilities
- `MagicGroupTeamAssistanceRatio` - team buff magic item sub-distribution probabilities
- `MagicGroupTeamModifier`- dynamic group weight offsets for team state (leading/trailing, by how many racers)
- `MagicSlotTeamModifier` - individual magic item catchup scaling in team mode
- `MagicConfig` - last spurt crit bonus buff (**85% is arbitrary, config declares this as last 500m but we only see relative in the racer progress**)