### PR TITLE
Fix cached login session after crash/disconnect

### DIFF
--- a/src/server/lobby/LobbyDirector.cpp
+++ b/src/server/lobby/LobbyDirector.cpp
@@ -465,28 +465,35 @@ void LobbyDirector::ProcesLoginResponse()
     return;
   }
 
-  const bool requiresCharacterCreator = _charactersForcedIntoCreator.erase(characterUid) > 0
-    || characterUid == data::InvalidUid;
-
-  _networkHandler->AcceptLogin(clientId, requiresCharacterCreator);
-
-  auto& userInstance = iter->second;
-  userInstance.userName = loginContext.userName;
-  userInstance.characterUid = characterUid;
-  spdlog::info(
-    "User '{}' (client {}) logged in from {}",
-    loginContext.userName,
-    clientId,
-    _networkHandler->GetCommandServer().GetClientAddress(clientId).to_string());
-
-  userRecord.Mutable([](data::User& user)
+  try 
   {
-    // Set the last seen online time to 1 to indicate that the user is currently online.
-    // NOTE: delete this once we have a proper api
-    user.lastSeenOnline() = data::Clock::time_point(std::chrono::seconds(1));
-  });
+    const bool requiresCharacterCreator = _charactersForcedIntoCreator.erase(characterUid) > 0
+      || characterUid == data::InvalidUid;
 
-  _clientLogins.erase(clientId);
+    _networkHandler->AcceptLogin(clientId, requiresCharacterCreator);
+
+    auto& userInstance = iter->second;
+    userInstance.userName = loginContext.userName;
+    userInstance.characterUid = characterUid;
+    spdlog::info(
+      "User '{}' (client {}) logged in from {}",
+      loginContext.userName,
+      clientId,
+      _networkHandler->GetCommandServer().GetClientAddress(clientId).to_string());
+
+    userRecord.Mutable([](data::User& user)
+    {
+      // Set the last seen online time to 1 to indicate that the user is currently online.
+      // NOTE: delete this once we have a proper api
+      user.lastSeenOnline() = data::Clock::time_point(std::chrono::seconds(1));
+    });
+
+    _clientLogins.erase(clientId);
+  } catch (...) 
+  {
+      _userInstances.erase(iter);
+      throw;
+  }
 }
 
 } // namespace server

--- a/src/server/lobby/LobbyNetworkHandler.cpp
+++ b/src/server/lobby/LobbyNetworkHandler.cpp
@@ -320,26 +320,19 @@ void LobbyNetworkHandler::AcceptLogin(
   ClientId clientId,
   const bool sendToCharacterCreator)
 {
-  try
+  auto& clientContext = GetClientContext(clientId, false);
+
+  clientContext.isAuthenticated = true;
+
+  if (sendToCharacterCreator)
   {
-    auto& clientContext = GetClientContext(clientId, false);
-
-    clientContext.isAuthenticated = true;
-
-    if (sendToCharacterCreator)
-    {
-      // Reset the waiting sequence number so the client does not soft lock.
-      // SendWaitingSeqno(clientId, 0);
-      SendCreateNicknameNotify(clientId);
-    }
-    else
-    {
-      SendLoginOK(clientId);
-    }
+    // Reset the waiting sequence number so the client does not soft lock.
+    // SendWaitingSeqno(clientId, 0);
+    SendCreateNicknameNotify(clientId);
   }
-  catch (const std::exception&)
+  else
   {
-    // We really don't care if the user disconnected.
+    SendLoginOK(clientId);
   }
 }
 


### PR DESCRIPTION
Fixes stale sessions left by disconnects during login, which blocked reconnects with “already logged in".